### PR TITLE
[feat] 사용자 정보 수정 및 삭제 기능 추가 (#6)

### DIFF
--- a/src/docs/swaggerDocs.ts
+++ b/src/docs/swaggerDocs.ts
@@ -68,7 +68,7 @@ export const authSwaggerDocs = {
     "/api/auth/me": {
       get: {
         summary: "사용자 정보 조회 API",
-        description: "로그인된 사용자의 정보를 반환(토큰 필요)",
+        description: "로그인된 사용자의 정보를 반환 (토큰 필요)",
         tags: ["Auth"],
         security: [
           {
@@ -100,6 +100,82 @@ export const authSwaggerDocs = {
           "500": {
             description: "서버 오류",
           },
+        },
+      },
+      put: {
+        summary: "사용자 정보 수정 API",
+        description: "사용자의 이름, 이메일, 비밀번호를 수정",
+        tags: ["Auth"],
+        security: [
+          {
+            bearerAuth: [],
+          },
+        ],
+        requestBody: {
+          required: true,
+          content: {
+            "application/json": {
+              schema: {
+                type: "object",
+                properties: {
+                  name: { type: "string", example: "newname" },
+                  email: { type: "string", example: "newemail@example.com" },
+                  password: { type: "string", example: "newpassword123" },
+                },
+              },
+            },
+          },
+        },
+        responses: {
+          "200": {
+            description: "사용자 정보 수정 성공",
+            content: {
+              "application/json": {
+                schema: {
+                  type: "object",
+                  properties: {
+                    _id: { type: "string", example: "abc123" },
+                    name: { type: "string", example: "newname" },
+                    email: { type: "string", example: "newemail@example.com" },
+                  },
+                },
+              },
+            },
+          },
+          "401": { description: "인증 실패" },
+          "404": { description: "사용자 없음" },
+          "500": { description: "서버 오류" },
+        },
+      },
+      delete: {
+        summary: "회원 탈퇴 API",
+        description: "현재 로그인된 사용자를 삭제",
+        tags: ["Auth"],
+        security: [
+          {
+            bearerAuth: [],
+          },
+        ],
+        responses: {
+          "200": {
+            description: "회원 탈퇴 성공",
+            content: {
+              "application/json": {
+                schema: {
+                  type: "object",
+                  properties: {
+                    message: {
+                      type: "string",
+                      example: "회원 탈퇴 완료",
+                    },
+                  },
+                },
+              },
+            },
+          },
+          "401": { description: "인증 실패" },
+          "404": { description: "사용자 없음" },
+          "500": { description: "서버 오류" },
         },
       },
     },

--- a/src/middlewares/authMiddleware.ts
+++ b/src/middlewares/authMiddleware.ts
@@ -1,9 +1,11 @@
 import jwt from "jsonwebtoken";
 import { Request, Response, NextFunction } from "express";
 import User from "../models/User";
+import bcrypt from "bcryptjs";
+import { UserDocument } from "../models/User";
 
 interface AuthRequest extends Request {
-  user?: any;
+  user?: UserDocument;
 }
 
 // JWT 인증 미들웨어
@@ -29,3 +31,56 @@ export const protect = async (
     res.status(401).json({ message: "토큰이 없습니다." });
   }
 };
+
+// 회원 정보 조회 미들웨어
+export const getUserProfile = async (req: AuthRequest, res: Response) => {
+  try {
+    if (!req.user) {
+      return res.status(404).json({ message: "사용자를 찾을 수 없습니다." });
+    }
+
+    // 비밀번호 제외한 사용자 정보만 반환
+    const user = await User.findById(req.user._id).select("-password");
+    res.json(user); // 사용자 정보 반환
+  } catch (error) {
+    res.status(500).json({ message: "서버 오류" });
+  }
+};
+
+// 회원 정보 수정 미들웨어
+export const updateUserProfile = async (req: AuthRequest, res: Response) => {
+  const { name, email, password } = req.body;
+
+  try {
+    if (!req.user) {
+      return res.status(404).json({ message: "사용자를 찾을 수 없습니다." });
+    }
+
+    const user = await User.findById(req.user._id);
+
+    if (!user) {
+      return res.status(404).json({ message: "사용자를 찾을 수 없습니다." });
+    }
+
+    // 이름, 이메일, 비밀번호 업데이트
+    if (name) user.name = name;
+    if (email) user.email = email;
+
+    if (password) {
+      const salt = await bcrypt.genSalt(10);
+      user.password = await bcrypt.hash(password, salt); // 비밀번호 해시화
+    }
+
+    await user.save(); // 변경사항 저장
+
+    res.json({
+      _id: user._id,
+      name: user.name,
+      email: user.email,
+    });
+  } catch (error) {
+    res.status(500).json({ message: "서버 오류" });
+  }
+};
+
+export { AuthRequest };

--- a/src/routes/authRoutes.ts
+++ b/src/routes/authRoutes.ts
@@ -2,8 +2,10 @@ import express from "express";
 import User from "../models/User";
 import { UserDocument } from "../models/User";
 import { protect } from "../middlewares/authMiddleware";
+import { AuthRequest } from "../middlewares/authMiddleware";
 import { generateToken } from "../utils/generateToken";
 import { asyncHandler } from "../utils/asyncHandler";
+import bcrypt from "bcryptjs";
 
 const router = express.Router();
 
@@ -60,6 +62,59 @@ router.get(
   protect,
   asyncHandler(async (req, res) => {
     res.json(req.user);
+  })
+);
+
+// 회원 정보 수정 API
+router.put(
+  "/me",
+  protect,
+  asyncHandler(async (req: AuthRequest, res) => {
+    const { name, email, password } = req.body;
+
+    try {
+      const user = await User.findById(req.user!._id);
+
+      if (!user) {
+        return res.status(404).json({ message: "사용자를 찾을 수 없습니다." });
+      }
+
+      // 이름이 변경되었을 경우, 이름 수정
+      if (name) user.name = name;
+
+      // 이메일이 변경되었을 경우, 이메일 수정
+      if (email) user.email = email;
+
+      // 비밀번호가 변경되었을 경우, 비밀번호 해시화 후 수정
+      if (password) user.password = password;
+
+      await user.save(); // 정보 저장
+
+      res.json({
+        _id: user._id,
+        name: user.name,
+        email: user.email,
+      });
+    } catch (error) {
+      res.status(500).json({ message: "서버 오류" });
+    }
+  })
+);
+
+// 회원 탈퇴 API
+router.delete(
+  "/me",
+  protect,
+  asyncHandler(async (req: AuthRequest, res) => {
+    const user = await User.findById(req.user!._id);
+
+    if (!user) {
+      return res.status(404).json({ message: "사용자를 찾을 수 없습니다." });
+    }
+
+    await user.deleteOne();
+
+    res.json({ message: "회원 탈퇴가 완료되었습니다." });
   })
 );
 


### PR DESCRIPTION
📌 개요
사용자 정보 수정 및 삭제 기능 추가

🗒️ 작업 내용 요약

1. 사용자 정보 수정 API (PUT /api/auth/me)

이름, 이메일, 비밀번호 변경 기능 추가

2. 사용자 정보 삭제 API (DELETE /api/auth/me)

로그인된 사용자의 계정을 삭제하는 기능 추가

3. Swagger API 문서 추가


🔗 관련 이슈
Closes #6 