### PR TITLE
[chore] GPT 응답 API 명세서 작성, 이력 등록 API 개선, GPT 응답 API 개선 (#14)

### DIFF
--- a/src/controllers/authController.ts
+++ b/src/controllers/authController.ts
@@ -54,12 +54,7 @@ export const login = async (req: Request, res: Response) => {
     return res.status(401).json({ message: "비밀번호가 틀렸습니다." });
   }
 
-  res.json({
-    _id: user._id,
-    name: user.name,
-    email: user.email,
-    token: generateToken(user._id.toString()),
-  });
+  res.status(201).send("로그인 성공!");
 };
 
 // 사용자 정보 조회

--- a/src/docs/swagger.ts
+++ b/src/docs/swagger.ts
@@ -1,7 +1,7 @@
 import swaggerJSDoc from "swagger-jsdoc";
 import swaggerUi from "swagger-ui-express";
 import { Express } from "express";
-import { authSwaggerDocs } from "../docs/swaggerDocs";
+import { authSwaggerDocs, profileSwaggerDocs } from "../docs/swaggerDocs";
 
 const options: swaggerJSDoc.Options = {
   definition: {
@@ -29,6 +29,7 @@ const options: swaggerJSDoc.Options = {
 
     paths: {
       ...authSwaggerDocs.paths,
+      ...profileSwaggerDocs.path,
     },
   },
   apis: [],

--- a/src/docs/swaggerDocs.ts
+++ b/src/docs/swaggerDocs.ts
@@ -1,6 +1,6 @@
+// Auth
 export const authSwaggerDocs = {
   paths: {
-    // Auth
     "/api/auth/register": {
       post: {
         summary: "회원가입 API",
@@ -27,6 +27,22 @@ export const authSwaggerDocs = {
         responses: {
           "201": {
             description: "회원가입 성공",
+            content: {
+              "application/json": {
+                schema: {
+                  type: "object",
+                  properties: {
+                    _id: {
+                      type: "string",
+                      example: "60c72b2f9b1d8c001c8a4b53",
+                    },
+                    name: { type: "string", example: "user1" },
+                    email: { type: "string", example: "user1@1111" },
+                    token: { type: "string", example: "token" },
+                  },
+                },
+              },
+            },
           },
           "400": {
             description: "이미 존재하는 사용자",
@@ -187,7 +203,12 @@ export const authSwaggerDocs = {
         },
       },
     },
-    //Profile
+  },
+};
+
+//Profile
+export const profileSwaggerDocs = {
+  path: {
     "/api/profile": {
       post: {
         summary: "사용자 이력 등록",
@@ -360,6 +381,90 @@ export const authSwaggerDocs = {
             },
           },
           404: { description: "이력 없음" },
+        },
+      },
+    },
+    "/api/profile/{id}/gpt": {
+      get: {
+        summary: "사용자 이력을 기반으로 GPT 응답 생성",
+        description:
+          "사용자의 이력 정보(학력, 경험, 기술 스택 등)를 GPT API로 전송하고 응답을 받습니다.",
+        tags: ["Profile"],
+        parameters: [
+          {
+            name: "id",
+            in: "path",
+            required: true,
+            schema: { type: "string" },
+            description: "사용자 이력 ID",
+          },
+        ],
+        security: [
+          {
+            bearerAuth: [],
+          },
+        ],
+        responses: {
+          200: {
+            description: "GPT 응답 생성 성공",
+            content: {
+              "application/json": {
+                schema: {
+                  type: "object",
+                  properties: {
+                    rankings: {
+                      type: "array",
+                      items: {
+                        type: "object",
+                        properties: {
+                          country: { type: "string", example: "캐나다" },
+                          job: { type: "string", example: "프론트엔드 개발자" },
+                          reason: {
+                            type: "string",
+                            example:
+                              "React와 AWS에 대한 경험이 북미 시장에서 높은 수요를 보입니다.",
+                          },
+                        },
+                      },
+                    },
+                  },
+                  example: {
+                    rankings: [
+                      {
+                        country: "미국",
+                        job: "프론트엔드 개발자",
+                        reason:
+                          "프론트엔드 개발에 대한 수요가 높고, 연봉이 높음",
+                      },
+                      {
+                        country: "캐나다",
+                        job: "프론트엔드 개발자",
+                        reason: "IT 산업이 발달하며 원격 근무 기회가 많음",
+                      },
+                      {
+                        country: "호주",
+                        job: "프론트엔드 개발자",
+                        reason: "영어권 국가로서 원격 근무 가능한 기업이 많음",
+                      },
+                    ],
+                  },
+                },
+              },
+            },
+          },
+
+          400: {
+            description: "잘못된 요청",
+          },
+          401: {
+            description: "인증 실패",
+          },
+          404: {
+            description: "사용자 이력 없음",
+          },
+          500: {
+            description: "서버 오류",
+          },
         },
       },
     },

--- a/src/services/gptService.ts
+++ b/src/services/gptService.ts
@@ -40,11 +40,41 @@ export const getGPTResponse = async (profile: any) => {
       {
         model: "gpt-4", // GPT-4 모델 사용
         messages: [
-          { role: "system", content: "You are a helpful assistant." },
-          { role: "user", content: prompt },
+          {
+            role: "system",
+            content: `당신은 경력 기반으로 대한민국을 제외한 해외의 직업을 추천해주는 도우미입니다. 
+        사용자의 정보를 바탕으로 아래 JSON 형식 그대로만 응답하세요:
+
+{
+  "rankings": [
+    {
+      "country": "국가명",
+      "job": "추천 직업",
+      "reason": "간단한 이유"
+    },
+    {
+      "country": "국가명",
+      "job": "추천 직업",
+      "reason": "간단한 이유"
+    },
+    {
+      "country": "국가명",
+      "job": "추천 직업",
+      "reason": "간단한 이유"
+    }
+  ]
+}
+
+⚠️ 위 JSON 형식 외에는 절대 아무것도 출력하지 마세요.`,
+          },
+          {
+            role: "user",
+            content: prompt,
+          },
         ],
-        max_tokens: 100,
-        temperature: 0.7,
+
+        max_tokens: 500,
+        temperature: 0,
       },
       {
         headers: {
@@ -54,7 +84,17 @@ export const getGPTResponse = async (profile: any) => {
       }
     );
 
-    return response.data; // GPT 응답 반환
+    const gptRaw = response.data?.choices?.[0]?.message?.content;
+    let gptParsed;
+
+    try {
+      gptParsed = JSON.parse(gptRaw);
+    } catch (err) {
+      console.error("GPT 응답 JSON 파싱 실패:", err);
+      throw new Error("잘못된 형식의 GPT 응답입니다.");
+    }
+
+    return gptParsed;
   } catch (error) {
     console.error("Error calling GPT API:", error);
     throw error;


### PR DESCRIPTION
## 📌 개요
- GPT 응답 API 명세서 작성, 이력 등록 API 개선, GPT 응답 API 개선

## 🗒️ 작업 내용 요약
- GET /api/profile/{이력 id}/gpt - GPT 응답 API / Swagger 명세서 작성

- POST /api/profile 성공 시 응답 변경

- 이력 등록 시 중복 방지

- GPT 응답 API 개선


## 🔗 관련 이슈
- Closes #14 