### PR TITLE
[feat] 취업 가능성 및 이주 추천도 구현 (#44)

### DIFF
--- a/src/controllers/mypageController.ts
+++ b/src/controllers/mypageController.ts
@@ -289,8 +289,6 @@ export const getUserSimulations = async (req: AuthRequest, res: Response) => {
         simulationId: simObj._id,
         country: simObj.country,
         recommendedCity: result.recommendedCity || null,
-        employmentProbability: result.employmentProbability || 0,
-        migrationSuitability: result.migrationSuitability || 0,
         localInfo: result.localInfo || {},
         initialSetup: result.initialSetup || {},
         jobReality: result.jobReality || {},
@@ -455,8 +453,7 @@ export const getSimulationsByProfileId = async (
         simulationId: obj._id,
         country: obj.country,
         recommendedCity: result.recommendedCity || null,
-        employmentProbability: result.employmentProbability || 0,
-        migrationSuitability: result.migrationSuitability || 0,
+
         localInfo: result.localInfo || {},
         initialSetup: result.initialSetup || {},
         jobReality: result.jobReality || {},

--- a/src/docs/simulationDocs.ts
+++ b/src/docs/simulationDocs.ts
@@ -393,5 +393,62 @@ export const simulationSwaggerDocs = {
         },
       },
     },
+    "/api/simulation/scores/{simulationInputId}": {
+      get: {
+        summary: "취업 가능성과 이주 추천도 계산",
+        tags: ["Simulation"],
+        security: [{ bearerAuth: [] }],
+        parameters: [
+          {
+            name: "simulationInputId",
+            in: "path",
+            required: true,
+            schema: { type: "string" },
+            description: "SimulationInput ID (MongoDB ObjectId)",
+          },
+        ],
+        responses: {
+          200: {
+            description: "점수 계산 성공",
+            content: {
+              "application/json": {
+                schema: {
+                  type: "object",
+                  properties: {
+                    code: {
+                      type: "integer",
+                      example: 200,
+                    },
+                    message: {
+                      type: "string",
+                      example: "점수 계산 성공",
+                    },
+                    data: {
+                      type: "object",
+                      properties: {
+                        employmentProbability: {
+                          type: "integer",
+                          example: 82,
+                        },
+                        migrationSuitability: {
+                          type: "integer",
+                          example: 74,
+                        },
+                      },
+                    },
+                  },
+                },
+              },
+            },
+          },
+          404: {
+            description: "입력 정보 또는 사용자 이력 정보 없음",
+          },
+          500: {
+            description: "서버 오류",
+          },
+        },
+      },
+    },
   },
 };

--- a/src/models/simulationInput.ts
+++ b/src/models/simulationInput.ts
@@ -19,7 +19,7 @@ const simulationInputSchema = new mongoose.Schema({
   hasLicense: { type: Boolean, required: true }, // 운전면허 여부
   jobTypes: [String], // 희망 취업 형태
   requiredFacilities: [String], // 필수 편의 시설
-  accompanyingFamily: [String], // 동반 가족 여부
+  accompanyingFamily: { type: String }, // 동반 가족 여부
   visaStatus: [String], // 비자 종류 및 상태
   additionalNotes: { type: String }, // 기타 희망사항
   selectedCity: { type: String }, // 선택 도시

--- a/src/models/simulationResult.ts
+++ b/src/models/simulationResult.ts
@@ -22,15 +22,16 @@ const simulationResultSchema = new mongoose.Schema({
       warnings: String,
     },
     // 한 달 예산 전략
-    // 주거비, 식비, 교통 비, 기타비용, 한 달 총 비용, 1년 비용, 절약 팁
+    // 주거비, 식비, 교통 비, 기타비용, 한 달 총 비용, 1년 비용, 절약 팁, 물가비교
     estimatedMonthlyCost: {
       housing: String,
       food: String,
       transportation: String,
       etc: String,
       total: String,
-      oneYearCost: Number,
+      oneYearCost: String,
       costCuttingTips: String,
+      cpi: String,
     },
 
     // 인근 공항
@@ -50,7 +51,7 @@ const simulationResultSchema = new mongoose.Schema({
       bankAccount: String,
     },
     // 취업 현실 정보
-    // 추천 직종, 구직 플랫폼, 취업 가능성, 언어 조건, 비자 조건
+    // 추천 직종, 구직 플랫폼, 언어 조건, 비자 조건
     jobReality: {
       commonJobs: [String],
       jobSearchPlatforms: [String],
@@ -59,16 +60,12 @@ const simulationResultSchema = new mongoose.Schema({
       visaLimitationTips: String,
     },
     // 문화 적응 도움 정보
-    // 한국인 비율, 외국인 비율, 한식당/한국마트 위치 정보, 다문화 적응 프로그램
-    // (타 국가 비율 평균과 함께) 제공
+    // 한국인 비율, 외국인 비율, 한식당/한국마트 위치 정보
     culturalIntegration: {
       koreanPopulationRate: String,
       foreignResidentRatio: String,
       koreanResourcesLinks: [String],
-      culturalIntegrationPrograms: [String],
     },
-    employmentProbability: { type: Number },
-    migrationSuitability: { type: Number },
   },
 });
 

--- a/src/routes/simulationRoutes.ts
+++ b/src/routes/simulationRoutes.ts
@@ -7,6 +7,7 @@ import {
   recommendCities,
 } from "../controllers/simulationController";
 import { getSimulationFlightLinks } from "../controllers/simulationController";
+import { calculateSimulationScores } from "../controllers/simulationController";
 
 const router = express.Router();
 
@@ -28,6 +29,12 @@ router.get(
   "/:id/flight-links",
   protect,
   asyncHandler(getSimulationFlightLinks)
+);
+// 취업 가능성 및 이주 추천도
+router.get(
+  "/scores/:simulationInputId",
+  protect,
+  asyncHandler(calculateSimulationScores)
 );
 
 export default router;

--- a/src/services/gptCalculation.ts
+++ b/src/services/gptCalculation.ts
@@ -1,78 +1,88 @@
-// 사용자 조건 기반 취업 가능성
-// 직업 수요도, 외국인 채용도, 현재 스펙으로 가능성
-export function calculateEmploymentProbability({
-  jobDemand,
-  foreignAcceptance,
-  specPreparation,
-}: {
-  jobDemand: number;
-  foreignAcceptance: number;
-  specPreparation: number;
+// 점수 매핑
+const levelMaps = {
+  jobDemand: { 높음: 1.0, 중간: 0.7, 낮음: 0.3, 거의없음: 0 },
+  foreignAcceptance: { 높음: 1.0, 중간: 0.7, 낮음: 0.3, 거의없음: 0 },
+  specPreparation: { 쉬움: 1.0, 보통: 0.6, 어려움: 0.3, 불가: 0.1 },
+
+  budgetLevel: {
+    "매우 적합": 1.0,
+    적당함: 0.7,
+    부족함: 0.5,
+    "매우 부족함": 0,
+  },
+
+  languageability: {
+    "매우 적합": 1.0,
+    적당함: 0.7,
+    부족함: 0.5,
+    "매우 부족함": 0,
+  },
+
+  accompanyLevel: {
+    "매우 적합": 1.0,
+    적당함: 0.7,
+    부족함: 0.5,
+    "매우 부족함": 0,
+  },
+  visaLevel: {
+    "매우 적합": 1.0,
+    적당함: 0.7,
+    부족함: 0.5,
+    "매우 부족함": 0,
+  },
+};
+
+// 1. 취업 가능성 계산 함수
+export function calculateEmploymentProbability(levels: {
+  jobDemandLevel: string;
+  foreignAcceptanceLevel: string;
+  specPreparationLevel: string;
 }): number {
-  const weights = {
-    jobDemand: 0.3,
-    foreignAcceptance: 0.3,
-    specPreparation: 0.4,
-  };
+  const jobScore =
+    (levelMaps.jobDemand[
+      levels.jobDemandLevel as keyof typeof levelMaps.jobDemand
+    ] ?? 0) *
+      0.4 +
+    (levelMaps.foreignAcceptance[
+      levels.foreignAcceptanceLevel as keyof typeof levelMaps.foreignAcceptance
+    ] ?? 0) *
+      0.3 +
+    (levelMaps.specPreparation[
+      levels.specPreparationLevel as keyof typeof levelMaps.specPreparation
+    ] ?? 0) *
+      0.3;
 
-  const score =
-    jobDemand * weights.jobDemand +
-    foreignAcceptance * weights.foreignAcceptance +
-    specPreparation * weights.specPreparation;
-
-  return Math.round(score * 100); // 퍼센트로 반환 (0~100)
+  return Math.round(jobScore * 100);
 }
 
-// 사용자 이력 기반 이주 추천도
-// 예산 적합도, 동반자 적합도, 한인 커뮤니티 지원, 언어 수준, 비자 유형
-export function calculateMigrationSuitability({
-  languageLevel,
-  visaType,
-  budgetSuitability,
-  familySuitability,
-  communitySupport,
-  employmentProbability,
-}: {
+// 2. 이주 추천도 계산 함수
+export function calculateMigrationSuitability(params: {
   languageLevel: string;
-  visaType: string;
-  budgetSuitability: number;
-  familySuitability: number;
-  communitySupport: number;
-  employmentProbability: number;
+  visaStatus: string;
+  budgetSuitabilityLevel: string;
+  hasCompanion: string;
+  employmentProbability: number; // 0~100 범위
 }): number {
-  const weights = {
-    languageLevel: 0.2, // 언어수준
-    visaType: 0.2, // 비자유형
-    budgetSuitability: 0.2, // 초기예산
-    familySuitability: 0.1, // 동반가족
-    communitySupport: 0.05, // 커뮤니티 지원
-    employmentProbability: 0.25, // 고용 가능성
-  };
+  const langScore =
+    (levelMaps.languageability[
+      params.languageLevel as keyof typeof levelMaps.languageability
+    ] ?? 0) * 0.2;
+  const visaScore =
+    (levelMaps.visaLevel[
+      params.visaStatus as keyof typeof levelMaps.visaLevel
+    ] ?? 0) * 0.2;
+  const budgetScore =
+    (levelMaps.budgetLevel[
+      params.budgetSuitabilityLevel as keyof typeof levelMaps.budgetLevel
+    ] ?? 0) * 0.2;
+  const companionScore =
+    levelMaps.accompanyLevel[
+      params.hasCompanion.toString() as keyof typeof levelMaps.accompanyLevel
+    ] * 0.2;
+  const employmentScore = (params.employmentProbability / 100) * 0.2;
 
-  const levelMap: Record<string, number> = {
-    능숙: 1.0,
-    중간: 0.5,
-    기초: 0.3,
-    불가: 0.0,
-  };
+  const total =
+    langScore + visaScore + budgetScore + companionScore + employmentScore;
 
-  const visaMap: Record<string, number> = {
-    취업비자: 1.0,
-    영주권: 1.0,
-    학생비자: 0.6,
-    무비자: 0.1,
-  };
-
-  const getMappedValue = (map: Record<string, number>, key: string): number =>
-    map[key] !== undefined ? map[key] : 0;
-
-  const score =
-    weights.languageLevel * getMappedValue(levelMap, languageLevel) +
-    weights.visaType * getMappedValue(visaMap, visaType) +
-    weights.budgetSuitability * budgetSuitability +
-    weights.familySuitability * familySuitability +
-    weights.communitySupport * communitySupport +
-    weights.employmentProbability * (employmentProbability / 100);
-
-  return Math.round(score * 100); // 퍼센트 반환
+  return Math.round(total * 100);
 }

--- a/src/services/gptJobAssessmentService.ts
+++ b/src/services/gptJobAssessmentService.ts
@@ -1,0 +1,69 @@
+import axios from "axios";
+const GPT_API_URL = process.env.GPT_API_URL as string;
+const API_KEY = process.env.API_KEY; // 환경변수 파일에 설정했다고 가정
+
+// 프롬프트 생성
+function getJobAssessmentPrompt(userData: any): string {
+  const {
+    education,
+    experience,
+    skills,
+    languages,
+    desiredSalary,
+    desiredJob,
+    additionalNotes,
+  } = userData;
+
+  return `
+당신은 이력서 평가 전문가입니다. 아래 사용자의 이력 정보를 기반으로 다음 세 가지를 판단해 주세요.
+
+1. 직업 수요도: 높음, 중간, 낮음, 거의없음
+2. 외국인 채용도: 높음, 중간, 낮음, 거의없음
+3. 직업 준비 난이도: 쉬움, 보통, 어려움, 불가
+
+이력 정보:
+- 학력: ${education}
+- 경력: ${experience}
+- 기술: ${skills?.join(", ") || "없음"}
+- 언어 능력: ${languages?.join(", ") || "없음"}
+- 희망 직무: ${desiredJob || "명시되지 않음"}
+- 희망 월급: ${desiredSalary || "명시되지 않음"}
+- 기타 사항: ${additionalNotes || "없음"}
+
+**아래와 같이 반드시 JSON 형식으로 정확하게 응답해 주세요.**
+모든 키와 문자열 값은 **반드시 큰따옴표(")**로 감싸야 합니다.
+⚠️ "반드시 JSON만 출력하세요. 설명 없이 JSON 객체만 출력하세요. 다른 텍스트를 포함하지 마세요."
+
+응답 형식 (JSON):
+{
+  "jobDemandLevel": "높음",
+  "foreignAcceptanceLevel": "보통",
+  "specPreparationLevel": "보통"
+}
+`;
+}
+
+// GPT 호출 함수
+export async function getJobLevelAssessment(userData: any): Promise<{
+  jobDemandLevel: string;
+  foreignAcceptanceLevel: string;
+  specPreparationLevel: string;
+}> {
+  const prompt = getJobAssessmentPrompt(userData);
+
+  const response = await axios.post(
+    GPT_API_URL,
+    {
+      model: "gpt-4",
+      messages: [{ role: "user", content: prompt }],
+    },
+    {
+      headers: {
+        Authorization: `Bearer ${API_KEY}`,
+      },
+    }
+  );
+
+  const parsed = JSON.parse(response.data.choices[0].message.content);
+  return parsed;
+}

--- a/src/services/gptMigrationAssessmentService.ts
+++ b/src/services/gptMigrationAssessmentService.ts
@@ -1,0 +1,69 @@
+import axios from "axios";
+const GPT_API_URL = process.env.GPT_API_URL as string;
+const API_KEY = process.env.API_KEY; // 환경변수 파일에 설정했다고 가정
+
+// 프롬프트 생성
+function getMigrationAssessmentPrompt(input: any): string {
+  const {
+    selectedCountry,
+    budget,
+    duration,
+    languageLevel,
+    accompanyingFamily,
+    visaStatus,
+  } = input;
+
+  return `
+당신은 이주 컨설턴트입니다. 아래 조건을 참고하여 예산이 해당 국가에서 생활에 적절한지를 판단해 주세요.
+
+조건:
+- 국가: ${selectedCountry}
+- 예산: ${budget}만원
+- 거주 기간: ${duration}
+- 언어 능력: ${languageLevel}
+- 동반 가족: ${accompanyingFamily}
+- 비자 상태: ${visaStatus.join(", ")}
+
+다음 중 하나의 값으로 평가:
+"매우 적합", "적당함", "부족함", "매우 부족함"
+**아래와 같이 반드시 JSON 형식으로 정확하게 응답해 주세요.**
+동반가족은 0명-"매우 적합", 1명-"적당함", 2명-"부족함", 3명 이상-"매우 부족함"으로 표시해주세요.
+모든 키와 문자열 값은 **반드시 큰따옴표(")**로 감싸야 합니다.
+⚠️ "반드시 JSON만 출력하세요. 설명 없이 JSON 객체만 출력하세요. 다른 텍스트를 포함하지 마세요."
+
+
+응답 형식 (JSON):
+{
+  "budgetLevel": "적당함",
+  "languageability": "매우 적합",
+  "accompanyLevel": "적당함",
+  "visaLevel": "매우 부족함",
+}
+`;
+}
+
+// GPT 호출 함수
+export async function getBudgetSuitability(input: any): Promise<{
+  budgetLevel: string;
+  languageability: string;
+  accompanyLevel: string;
+  visaLevel: string;
+}> {
+  const prompt = getMigrationAssessmentPrompt(input);
+
+  const response = await axios.post(
+    GPT_API_URL,
+    {
+      model: "gpt-4",
+      messages: [{ role: "user", content: prompt }],
+    },
+    {
+      headers: {
+        Authorization: `Bearer ${API_KEY}`,
+      },
+    }
+  );
+
+  const parsed = JSON.parse(response.data.choices[0].message.content);
+  return parsed;
+}

--- a/src/services/gptsimulationService.ts
+++ b/src/services/gptsimulationService.ts
@@ -30,11 +30,11 @@ export const getCityRecommendations = async (input: any) => {
 - 운전면허: ${hasLicense ? "보유" : "없음"}
 - 취업 형태: ${jobTypes.join(", ")}
 - 필수 편의시설: ${requiredFacilities.join(", ")}
-- 동반 가족: ${accompanyingFamily.join(", ") || "없음"}
+- 동반 가족: ${accompanyingFamily}
 - 비자 상태: ${visaStatus.join(", ")}
 - 기타: ${additionalNotes || "없음"}
 
-⚠️ 아래 JSON 형식 그대로만 응답하세요:
+⚠️ 아래 JSON 형식 그대로만 한글로 응답하세요:
 
 {
   "cities": [
@@ -71,7 +71,6 @@ export const getCityRecommendations = async (input: any) => {
 // 선택된 도시 기반 시뮬레이션 GPT 호출
 export const generateSimulationResponse = async (input: any) => {
   const {
-    selectedCountry,
     selectedCity,
     budget,
     duration,
@@ -94,39 +93,66 @@ export const generateSimulationResponse = async (input: any) => {
 - 필수 편의시설: ${requiredFacilities.join(", ")}
 - 언어 능력: ${languageLevel}
 - 비자 상태: ${visaStatus.join(", ")}
-- 동반 가족: ${accompanyingFamily.join(", ") || "없음"}
+- 동반 가족: ${accompanyingFamily}
 - 기타: ${additionalNotes || "없음"}
 
 아래 항목을 포함하여 현실적인 시뮬레이션을 JSON 형식으로 응답하세요:
 
 ⚠️ 반드시 아래 예시 형식의 JSON으로만 응답하세요.
+단, 값은 사용자의 조건을 바탕으로 평가하여 예시 값을 따라하지말고 실제 값으로 작성해야 합니다.
 
 
 {
   "simulation": {
     "recommendedCity": "도시명",
     "localInfo": {
-      "publicTransport": "교통 요약",
-      "safetyLevel": "치안 수준",
-      "climateSummary": "기후 요약",
-      "essentialFacilities": ["병원", "마트", "은행"]
+      "publicTransport": "버스와 지하철이 주요 교통수단입니다.",
+      "safetyLevel": "대한민국과 비교하여 치안이 조금 낮으니 주의 필요",
+      "climateSummary": "사계절이 뚜렷하며 겨울에 눈이 자주 내림",
+      "koreanCommunity": "한인 마트와 한식당이 밀집된 지역이 있음",
+      "essentialFacilities": ["가까운 대형 병원명", "가까운 대형 마트명", "가까운 대사관명"],
+      "culturalTips": "현지인은 정시에 민감하고 예절을 중시함",
+      "warnings": "겨울철 눈길 교통사고 다발지역 주의"
     },
+
+    "estimatedMonthlyCost": {
+      "housing": "60만원",
+      "food": "30만원",
+      "transportation": "10만원",
+      "etc": "20만원",
+      "total": "120만원",
+      "oneYearCost": "1440만원",
+      "costCuttingTips": "공공 교통 패스 이용 추천, 중고 가구 활용",
+      "cpi" : "대한민국 보다 1.5배 정도 물가가 낮은 편입니다."
+    },
+
+    "nearestAirport": {
+      "name": "인천국제공항",
+      "city": "인천",
+      "code": "ICN"
+    },
+
     "initialSetup": {
-      "shortTermHousingOptions": ["호텔", "에어비앤비"],
-      "longTermHousingPlatforms": ["Zumper", "Immoweb"]
+      "shortTermHousingOptions": ["호텔", "호스텔", "에어비앤비"],
+      "longTermHousingPlatforms": ["Zumper", "Immoweb"],
+      "mobilePlan": "선불 심카드가 편리함 (예: Lycamobile)",
+      "bankAccount": "여권과 주소 증빙만으로 계좌 개설 가능"
     },
+
     "jobReality": {
-      "commonJobs": ["요식업", "물류"],
-      "jobSearchPlatforms":
-       ["Indeed", "LinkedIn"]
+      "commonJobs": "사용자가 희망하는 직종과 관련된 직종 중 추천하는 직종",
+      "jobSearchPlatforms": ["Indeed", "LinkedIn", "Workopolis"],
+      "languageRequirement": "영어 중급 이상 필수 또는 일본어 기초 필요",
+      "visaLimitationTips": "취업 비자는 고용주 스폰서 필요"
     },
+
     "culturalIntegration": {
-      "koreanResourcesLinks": ["https://korean-community.com"],
-      "culturalIntegrationPrograms": ["언어교류", "지역 커뮤니티"]
-    }
+      "koreanPopulationRate": "전체 인구의 약 1.2% 이므로 타국가에 비해 한국인이 많은 편",
+      "foreignResidentRatio": "15%",
+      "koreanResourcesLinks": ["https://korea-center.ca", "https://hanin.ca"]
+    },
   }
 }
-
 `;
 
   const systemMessage = `당신은 해외 이주 시뮬레이션 전문가입니다. 사용자 조건을 바탕으로 실제적이고 현실적인 데이터를 제공합니다.`;

--- a/src/types/simulation.ts
+++ b/src/types/simulation.ts
@@ -9,7 +9,7 @@ export interface SimulationInputWithCity {
   hasLicense: boolean;
   jobPreference: string;
   accommodation: string;
-  withFamily: boolean;
+  withFamily: string;
   visaStatus: string;
   extraWishes?: string;
 }
@@ -46,7 +46,7 @@ export interface MigrationFactors {
   languageLevel: number;
   visaScore: number;
   budgetScore: number;
-  withFamily: boolean;
+  withFamily: string;
   koreanCommunityScore: number;
   employmentProbability: number;
 }


### PR DESCRIPTION
## 📌 개요
- 취업 가능성 및 이주 추천도 구현

## 🗒️ 작업 내용 요약
- gptJobAssessmentService - 사용자 이력 보고 gpt의 평가로 취업 가능성 계산
- gptMigrationAssessmentService - 사용자 시뮬레이션 전 추가 정보 기반 이주 추천도 계산

## 🔗 관련 이슈
- Closes #44 
