### PR TITLE
[feat] API 기반 국가 추천 기능 구현, 이주추천도 및 취업 가능성 삭제 (#54)

### DIFF
--- a/package.json
+++ b/package.json
@@ -24,7 +24,7 @@
     "typescript": "^5.8.2"
   },
   "dependencies": {
-    "axios": "^1.8.4",
+    "axios": "^1.12.2",
     "bcrypt": "^6.0.0",
     "cors": "^2.8.5",
     "dotenv": "^16.4.7",

--- a/src/app.ts
+++ b/src/app.ts
@@ -7,6 +7,7 @@ import simulationRoutes from "./routes/simulationRoutes";
 import mypageRoutes from "./routes/mypageRoutes";
 import rankingRoutes from "./routes/rankingRoutes";
 import guestRoutes from "./routes/guestRoutes";
+import countryRecommendationRoutes from "./routes/countryRecommendationRoutes";
 import { setupSwagger } from "./docs/swagger";
 
 const app = express();
@@ -21,6 +22,7 @@ app.use("/api/simulation", simulationRoutes);
 app.use("/api/mypage", mypageRoutes);
 app.use("/api/ranking", rankingRoutes);
 app.use("/api/guest", guestRoutes);
+app.use("/api/country-recommendations", countryRecommendationRoutes);
 
 // Swagger 문서
 setupSwagger(app);

--- a/src/constants/dropdownOptions.ts
+++ b/src/constants/dropdownOptions.ts
@@ -1,0 +1,112 @@
+// 클라이언트에서 사용할 드롭다운 옵션 데이터
+
+// 지원 가능한 언어 목록
+export const SUPPORTED_LANGUAGES = [
+  "Korean",
+  "English", 
+  "Chinese",
+  "Japanese",
+  "Spanish",
+  "French",
+  "German",
+  "Italian",
+  "Portuguese",
+  "Russian",
+  "Arabic",
+  "Hindi",
+  "Dutch",
+  "Swedish",
+  "Norwegian",
+] as const;
+
+// 직무 분야 목록 (ILOSTAT ISCO-08 대분류 기준)
+export const JOB_FIELDS = [
+  {
+    code: "1",
+    nameKo: "관리자",
+    nameEn: "Managers",
+    description: "기업, 정부, 기타 조직의 정책 수립 및 계획 수립, 조정, 감독",
+  },
+  {
+    code: "2",
+    nameKo: "전문가",
+    nameEn: "Professionals", 
+    description: "과학, 공학, 의학, 교육, 법률, 사회과학, 인문학 등 전문 분야",
+  },
+  {
+    code: "3",
+    nameKo: "기술자 및 준전문가",
+    nameEn: "Technicians and Associate Professionals",
+    description: "기술적 업무 수행 및 전문가 지원 업무",
+  },
+  {
+    code: "4",
+    nameKo: "사무종사자",
+    nameEn: "Clerical Support Workers",
+    description: "사무, 회계, 고객서비스 등 일반 사무 업무",
+  },
+  {
+    code: "5",
+    nameKo: "서비스 및 판매 종사자",
+    nameEn: "Service and Sales Workers",
+    description: "개인서비스, 보안서비스, 판매 업무",
+  },
+  {
+    code: "6",
+    nameKo: "농림어업 숙련 종사자",
+    nameEn: "Skilled Agricultural, Forestry and Fishery Workers",
+    description: "농업, 임업, 어업 분야 숙련 업무",
+  },
+  {
+    code: "7",
+    nameKo: "기능원 및 관련 기능 종사자",
+    nameEn: "Craft and Related Trades Workers",
+    description: "건설, 금속가공, 기계, 전기 등 기능 업무",
+  },
+  {
+    code: "8",
+    nameKo: "설비·기계 조작 및 조립 종사자",
+    nameEn: "Plant and Machine Operators and Assemblers",
+    description: "산업기계 및 설비 조작, 운송장비 운전, 조립 업무",
+  },
+  {
+    code: "9",
+    nameKo: "단순노무 종사자",
+    nameEn: "Elementary Occupations",
+    description: "청소, 건설보조, 제조업 단순작업 등",
+  },
+  {
+    code: "0",
+    nameKo: "군인",
+    nameEn: "Armed Forces Occupations",
+    description: "국방 및 군사 업무",
+  },
+] as const;
+
+// 우선순위 옵션
+export const PRIORITY_OPTIONS = {
+  language: {
+    label: "언어 호환성",
+    description: "사용 가능한 언어와 현지 언어의 일치도",
+  },
+  salary: {
+    label: "연봉 조건", 
+    description: "희망 연봉 달성 가능성",
+  },
+  job: {
+    label: "직무 기회",
+    description: "해당 직무 분야의 취업 기회",
+  },
+} as const;
+
+// 우선순위 가중치
+export const PRIORITY_WEIGHTS = {
+  first: 0.5,  // 1순위 가중치
+  second: 0.3, // 2순위 가중치  
+  third: 0.2,  // 3순위 가중치
+} as const;
+
+// 타입 정의
+export type SupportedLanguage = typeof SUPPORTED_LANGUAGES[number];
+export type JobFieldCode = typeof JOB_FIELDS[number]["code"];
+export type PriorityOption = keyof typeof PRIORITY_OPTIONS;

--- a/src/controllers/countryRecommendationController.ts
+++ b/src/controllers/countryRecommendationController.ts
@@ -1,0 +1,373 @@
+import { Request, Response } from "express";
+import {
+  UserCareerProfile,
+  CountryRecommendation,
+} from "../types/countryRecommendation";
+import { CountryRecommendationService } from "../services/countryRecommendationService";
+import { asyncHandler } from "../utils/asyncHandler";
+import CountryRecommendationResult from "../models/countryRecommendationResult";
+import UserProfile from "../models/UserProfile";
+import { AuthRequest } from "../middlewares/authMiddleware";
+import { SUPPORTED_LANGUAGES, JOB_FIELDS } from "../constants/dropdownOptions";
+
+// 인증된 사용자의 특정 프로필 기반 국가 추천 (중복 체크 및 저장)
+export const getCountryRecommendations = asyncHandler(
+  async (req: Request, res: Response) => {
+    const authReq = req as AuthRequest;
+    const userProfile: UserCareerProfile = req.body;
+    const { profileId } = req.params; // URL 파라미터에서 profileId 가져오기
+
+    // 인증된 사용자 확인
+    if (!authReq.user) {
+      return res.status(401).json({
+        success: false,
+        message: "인증이 필요합니다.",
+      });
+    }
+
+    // profileId 필수 확인
+    if (!profileId) {
+      return res.status(400).json({
+        success: false,
+        message: "프로필 ID가 필요합니다.",
+      });
+    }
+
+    // 입력 데이터 검증
+    const validationError = validateUserProfile(userProfile);
+    if (validationError) {
+      return res.status(400).json({
+        success: false,
+        message: validationError,
+      });
+    }
+
+    // 인증된 사용자이고 profileId가 있는 경우 중복 체크 및 저장 처리
+    if (authReq.user && profileId) {
+      // 해당 프로필 조회
+      const dbProfile = await UserProfile.findOne({
+        _id: profileId,
+        user: authReq.user._id,
+      });
+
+      if (!dbProfile) {
+        return res.status(404).json({
+          success: false,
+          message: "프로필을 찾을 수 없습니다.",
+        });
+      }
+
+      // 이미 해당 프로필에 대한 추천 결과가 있는지 확인
+      const existingRecommendation = await CountryRecommendationResult.findOne({
+        user: authReq.user._id,
+        profile: profileId,
+      }).sort({ createdAt: -1 });
+
+      if (existingRecommendation) {
+        return res.status(200).json({
+          success: true,
+          message: "이미 추천받은 이력입니다.",
+          data: {
+            isExisting: true,
+            recommendationId: existingRecommendation._id,
+            profileId: profileId,
+            createdAt: existingRecommendation.createdAt,
+          },
+        });
+      }
+    }
+
+    console.log("국가 추천 요청:", {
+      language: userProfile.language,
+      expectedSalary: userProfile.expectedSalary,
+      jobField: userProfile.jobField,
+      priorities: userProfile.priorities,
+    });
+
+    try {
+      // 국가 추천 서비스 호출
+      const recommendations: CountryRecommendation[] =
+        await CountryRecommendationService.getTopCountryRecommendations(
+          userProfile
+        );
+
+      // 인증된 사용자이고 profileId가 있는 경우 결과 저장
+      let savedRecommendationId = null;
+      if (authReq.user && profileId) {
+        const savedResult = new CountryRecommendationResult({
+          user: authReq.user._id,
+          profile: profileId,
+          recommendations: recommendations.map((rec, index) => ({
+            country: rec.country.name,
+            score: rec.totalScore,
+            rank: index + 1,
+            details: {
+              economicScore: rec.breakdown.languageScore,
+              employmentScore: rec.breakdown.jobScore,
+              languageScore: rec.breakdown.languageScore,
+              salaryScore: rec.breakdown.salaryScore,
+            },
+            economicData: {
+              gdpPerCapita: rec.country.gdpPerCapita || 0,
+              employmentRate: rec.country.employmentRate || 0,
+              averageSalary: 0,
+            },
+            countryInfo: {
+              region: rec.country.region,
+              languages: rec.country.languages,
+              population: rec.country.population || 0,
+            },
+          })),
+        });
+
+        await savedResult.save();
+        savedRecommendationId = savedResult._id;
+      }
+
+      res.status(200).json({
+        success: true,
+        message:
+          authReq.user && profileId
+            ? "국가 추천이 완료되고 저장되었습니다."
+            : "국가 추천이 완료되었습니다.",
+        data: {
+          isExisting: false,
+          recommendationId: savedRecommendationId,
+          profileId: profileId || null,
+          userProfile: {
+            language: userProfile.language,
+            expectedSalary: userProfile.expectedSalary,
+            jobField: userProfile.jobField,
+            priorities: userProfile.priorities,
+          },
+          recommendations,
+          appliedWeights: {
+            first: 0.5,
+            second: 0.3,
+            third: 0.2,
+          },
+          timestamp: new Date().toISOString(),
+        },
+      });
+    } catch (error) {
+      console.error("국가 추천 처리 오류:", error);
+
+      res.status(500).json({
+        success: false,
+        message: "국가 추천 처리 중 서버 오류가 발생했습니다.",
+        error: process.env.NODE_ENV === "development" ? error : undefined,
+      });
+    }
+  }
+);
+
+// 인증된 사용자용 국가 추천 (결과 저장)
+export const getCountryRecommendationsForUser = asyncHandler(
+  async (req: AuthRequest, res: Response) => {
+    const { profileId } = req.body;
+
+    if (!req.user) {
+      return res.status(401).json({
+        success: false,
+        message: "인증이 필요합니다.",
+      });
+    }
+
+    // profileId가 필수로 제공되어야 함
+    if (!profileId) {
+      return res.status(400).json({
+        success: false,
+        message: "profileId가 필요합니다.",
+      });
+    }
+
+    // 해당 프로필 조회
+    const userProfile = await UserProfile.findOne({
+      _id: profileId,
+      user: req.user._id,
+    });
+
+    if (!userProfile) {
+      return res.status(404).json({
+        success: false,
+        message: "프로필을 찾을 수 없습니다.",
+      });
+    }
+
+    // 이미 해당 프로필에 대한 추천 결과가 있는지 확인
+    const existingRecommendation = await CountryRecommendationResult.findOne({
+      user: req.user._id,
+      profile: profileId,
+    }).sort({ createdAt: -1 });
+
+    if (existingRecommendation) {
+      return res.status(200).json({
+        success: true,
+        message: "이미 추천받은 이력입니다.",
+        data: {
+          isExisting: true,
+          recommendationId: existingRecommendation._id,
+          profileId: profileId,
+          createdAt: existingRecommendation.createdAt,
+        },
+      });
+    }
+
+    // UserProfile을 UserCareerProfile로 변환
+    const careerProfile: UserCareerProfile = {
+      language: userProfile.language,
+      expectedSalary: userProfile.desiredSalary
+        ? parseInt(userProfile.desiredSalary.replace(/[^0-9]/g, ""))
+        : 50000,
+      jobField: userProfile.desiredJob
+        ? {
+            code: "2", // 기본값으로 "전문가" 설정
+            nameKo: userProfile.desiredJob.mainCategory || "기타",
+            nameEn: "Professionals",
+          }
+        : {
+            code: "2",
+            nameKo: "기타",
+            nameEn: "Other",
+          },
+      priorities: req.body.priorities || {
+        first: "language",
+        second: "salary",
+        third: "job",
+      },
+    };
+
+    // 입력 데이터 검증
+    const validationError = validateUserProfile(careerProfile);
+    if (validationError) {
+      return res.status(400).json({
+        success: false,
+        message: validationError,
+      });
+    }
+
+    try {
+      // 국가 추천 서비스 호출
+      const recommendations: CountryRecommendation[] =
+        await CountryRecommendationService.getTopCountryRecommendations(
+          careerProfile
+        );
+
+      // 추천 결과 저장
+      const savedResult = new CountryRecommendationResult({
+        user: req.user._id,
+        profile: userProfile._id,
+        recommendations: recommendations.map((rec, index) => ({
+          country: rec.country.name,
+          score: rec.totalScore,
+          rank: index + 1,
+          details: {
+            economicScore: rec.breakdown.languageScore,
+            employmentScore: rec.breakdown.jobScore,
+            languageScore: rec.breakdown.languageScore,
+            salaryScore: rec.breakdown.salaryScore,
+          },
+          economicData: {
+            gdpPerCapita: rec.country.gdpPerCapita || 0,
+            employmentRate: rec.country.employmentRate || 0,
+            averageSalary: 0, // 현재 타입에 없음
+          },
+          countryInfo: {
+            region: rec.country.region,
+            languages: rec.country.languages,
+            population: rec.country.population || 0,
+          },
+        })),
+      });
+
+      await savedResult.save();
+
+      res.status(200).json({
+        success: true,
+        message: "국가 추천이 완료되고 저장되었습니다.",
+        data: {
+          isExisting: false,
+          recommendationId: savedResult._id,
+          profileId: profileId,
+          userProfile: {
+            language: careerProfile.language,
+            expectedSalary: careerProfile.expectedSalary,
+            jobField: careerProfile.jobField,
+            priorities: careerProfile.priorities,
+          },
+          recommendations,
+          appliedWeights: {
+            first: 0.5,
+            second: 0.3,
+            third: 0.2,
+          },
+          timestamp: new Date().toISOString(),
+        },
+      });
+    } catch (error) {
+      console.error("국가 추천 처리 오류:", error);
+
+      res.status(500).json({
+        success: false,
+        message: "국가 추천 처리 중 서버 오류가 발생했습니다.",
+        error: process.env.NODE_ENV === "development" ? error : undefined,
+      });
+    }
+  }
+);
+
+// 사용자 프로필 검증 함수
+function validateUserProfile(profile: UserCareerProfile): string | null {
+  // 필수 필드 검증
+  if (!profile.language || profile.language.trim() === "") {
+    return "사용 가능한 언어를 선택해주세요.";
+  }
+
+  if (!profile.expectedSalary || profile.expectedSalary <= 0) {
+    return "유효한 희망 연봉을 입력해주세요.";
+  }
+
+  if (!profile.jobField || !profile.jobField.code || !profile.jobField.nameKo) {
+    return "직무 분야를 올바르게 선택해주세요.";
+  }
+
+  // ISCO 코드 유효성 검증
+  const validISCOCodes: string[] = JOB_FIELDS.map((field) => field.code);
+  if (!validISCOCodes.includes(profile.jobField.code)) {
+    return "ISCO-08 표준 직무 분류 코드를 선택해주세요.";
+  }
+
+  if (!profile.priorities) {
+    return "우선순위를 설정해주세요.";
+  }
+
+  // 우선순위 검증
+  const { first, second, third } = profile.priorities;
+  const validPriorities = ["language", "salary", "job"];
+
+  if (
+    !validPriorities.includes(first) ||
+    !validPriorities.includes(second) ||
+    !validPriorities.includes(third)
+  ) {
+    return "우선순위는 language, salary, job 중에서 선택해주세요.";
+  }
+
+  // 우선순위 중복 검증
+  const prioritySet = new Set([first, second, third]);
+  if (prioritySet.size !== 3) {
+    return "우선순위는 서로 다른 값이어야 합니다.";
+  }
+
+  // 연봉 범위 검증
+  if (profile.expectedSalary < 10000 || profile.expectedSalary > 500000) {
+    return "희망 연봉은 $10,000 ~ $500,000 범위로 입력해주세요.";
+  }
+
+  // 언어 검증
+  if (!SUPPORTED_LANGUAGES.includes(profile.language as any)) {
+    return "지원되는 언어를 선택해주세요.";
+  }
+
+  return null; // 검증 통과
+}

--- a/src/controllers/guestController.ts
+++ b/src/controllers/guestController.ts
@@ -1,36 +1,142 @@
 import { Request, Response } from "express";
-import { GuestProfile } from "../types/guestProfile";
-import { getGPTResponse } from "../services/gptService";
+import {
+  UserCareerProfile,
+  CountryRecommendation,
+} from "../types/countryRecommendation";
+import { CountryRecommendationService } from "../services/countryRecommendationService";
+import { asyncHandler } from "../utils/asyncHandler";
 
-// 비회원 GPT 기반 국가 추천
-export const recommendCountriesForGuest = async (
-  req: Request,
-  res: Response
-) => {
-  try {
-    const { languages, desiredSalary, desiredJob, additionalNotes } = req.body;
+// 비회원 국가 추천 요청 처리 (회원과 동일한 로직, DB 저장 없음)
+export const getGuestCountryRecommendations = asyncHandler(
+  async (req: Request, res: Response) => {
+    const userProfile: UserCareerProfile = req.body;
 
-    const guestProfile: GuestProfile = {
-      languages,
-      desiredSalary,
-      desiredJob,
-      additionalNotes,
-    };
+    // 입력 데이터 검증
+    const validationError = validateGuestProfile(userProfile);
+    if (validationError) {
+      return res.status(400).json({
+        success: false,
+        message: validationError,
+      });
+    }
 
-    const recommendedCountries = await getGPTResponse(guestProfile);
-
-    res.status(200).json({
-      code: 200,
-      message: "국가 추천 완료",
-      data: {
-        recommendedCountries,
-      },
+    console.log("비회원 국가 추천 요청:", {
+      language: userProfile.language,
+      expectedSalary: userProfile.expectedSalary,
+      jobField: userProfile.jobField,
+      priorities: userProfile.priorities,
     });
-  } catch (error) {
-    console.error("비회원 국가 추천 오류:", error);
-    res.status(500).json({
-      code: 500,
-      message: "국가 추천 실패",
-    });
+
+    try {
+      // 국가 추천 서비스 호출 (회원과 동일한 로직)
+      const recommendations: CountryRecommendation[] =
+        await CountryRecommendationService.getTopCountryRecommendations(
+          userProfile
+        );
+
+      res.status(200).json({
+        success: true,
+        message: "비회원 국가 추천이 완료되었습니다.",
+        data: {
+          userProfile: {
+            language: userProfile.language,
+            expectedSalary: userProfile.expectedSalary,
+            jobField: userProfile.jobField,
+            priorities: userProfile.priorities,
+          },
+          recommendations,
+          appliedWeights: {
+            first: 0.5,
+            second: 0.3,
+            third: 0.2,
+          },
+          timestamp: new Date().toISOString(),
+          note: "비회원은 국가 추천까지만 제공됩니다. 시뮬레이션 기능을 이용하려면 회원가입이 필요합니다.",
+        },
+      });
+    } catch (error) {
+      console.error("비회원 국가 추천 처리 오류:", error);
+
+      res.status(500).json({
+        success: false,
+        message: "국가 추천 처리 중 서버 오류가 발생했습니다.",
+        error: process.env.NODE_ENV === "development" ? error : undefined,
+      });
+    }
   }
+);
+
+// 비회원 프로필 검증 함수 (회원과 동일한 검증)
+function validateGuestProfile(profile: UserCareerProfile): string | null {
+  // 필수 필드 검증
+  if (!profile.language || profile.language.trim() === "") {
+    return "사용 가능한 언어를 선택해주세요.";
+  }
+
+  if (!profile.expectedSalary || profile.expectedSalary <= 0) {
+    return "유효한 희망 연봉을 입력해주세요.";
+  }
+
+  if (!profile.jobField || !profile.jobField.code || !profile.jobField.nameKo) {
+    return "직무 분야를 올바르게 선택해주세요.";
+  }
+
+  // ISCO 코드 유효성 검증
+  const validISCOCodes = ["0", "1", "2", "3", "4", "5", "6", "7", "8", "9"];
+  if (!validISCOCodes.includes(profile.jobField.code)) {
+    return "ISCO-08 표준 직무 분류 코드를 선택해주세요.";
+  }
+
+  if (!profile.priorities) {
+    return "우선순위를 설정해주세요.";
+  }
+
+  // 우선순위 검증
+  const { first, second, third } = profile.priorities;
+  const validPriorities = ["language", "salary", "job"];
+
+  if (
+    !validPriorities.includes(first) ||
+    !validPriorities.includes(second) ||
+    !validPriorities.includes(third)
+  ) {
+    return "우선순위는 language, salary, job 중에서 선택해주세요.";
+  }
+
+  // 우선순위 중복 검증
+  const prioritySet = new Set([first, second, third]);
+  if (prioritySet.size !== 3) {
+    return "우선순위는 서로 다른 값이어야 합니다.";
+  }
+
+  // 연봉 범위 검증
+  if (profile.expectedSalary < 10000 || profile.expectedSalary > 500000) {
+    return "희망 연봉은 $10,000 ~ $500,000 범위로 입력해주세요.";
+  }
+
+  // 언어 검증
+  const supportedLanguages = [
+    "English",
+    "Japanese",
+    "Chinese",
+    "German",
+    "French",
+    "Spanish",
+    "Korean",
+    "Other",
+  ];
+  if (!supportedLanguages.includes(profile.language)) {
+    return "지원되는 언어를 선택해주세요.";
+  }
+
+  return null; // 검증 통과
+}
+
+export const deprecatedNotice = async (req: Request, res: Response) => {
+  res.status(410).json({
+    code: 410,
+    message:
+      "이 기능은 더 이상 지원되지 않습니다. /api/guest/recommend를 사용하세요.",
+    data: null,
+  });
 };

--- a/src/controllers/profileController.ts
+++ b/src/controllers/profileController.ts
@@ -1,43 +1,14 @@
 import { Request, Response } from "express";
 import UserProfile from "../models/UserProfile";
 import { AuthRequest } from "../middlewares/authMiddleware";
-import { getGPTResponse } from "../services/gptService";
-import GptRecommendation from "../models/gptRecommendation";
 import { Types } from "mongoose";
 
 // 사용자 이력 등록 (POST /api/profile)
 export const createProfile = async (req: AuthRequest, res: Response) => {
-  const { languages, desiredSalary, desiredJob, additionalNotes } = req.body;
+  const { language, desiredSalary, desiredJob, additionalNotes } = req.body;
 
   // 이전 이력과 동일한 내용이면 등록 불가
   const normalize = (value: string) => (value || "").trim().toLowerCase();
-
-  // 언어 능력 비교 함수
-  const compareLanguages = (a: any[], b: any[]) => {
-    if (!a || !b || a.length !== b.length) return false;
-
-    // null 체크와 language 속성 존재 확인
-    const validA = a.filter(
-      (item) => item && item.language && typeof item.language === "string"
-    );
-    const validB = b.filter(
-      (item) => item && item.language && typeof item.language === "string"
-    );
-
-    if (validA.length !== validB.length) return false;
-
-    const sortedA = validA.sort((x, y) =>
-      (x.language || "").localeCompare(y.language || "")
-    );
-    const sortedB = validB.sort((x, y) =>
-      (x.language || "").localeCompare(y.language || "")
-    );
-
-    return sortedA.every(
-      (val, i) =>
-        val.language === sortedB[i].language && val.level === sortedB[i].level
-    );
-  };
 
   // 직무 카테고리 비교 함수
   const compareJobCategory = (a: any, b: any) => {
@@ -50,7 +21,7 @@ export const createProfile = async (req: AuthRequest, res: Response) => {
 
   const isDuplicate = existingProfiles.find((profile) => {
     return (
-      compareLanguages(profile.languages, languages) &&
+      profile.language === language &&
       profile.desiredSalary === desiredSalary &&
       compareJobCategory(profile.desiredJob, desiredJob) &&
       normalize(profile.additionalNotes || "") ===
@@ -70,7 +41,7 @@ export const createProfile = async (req: AuthRequest, res: Response) => {
 
   const profile = await UserProfile.create({
     user: req.user!._id,
-    languages,
+    language,
     desiredSalary,
     desiredJob,
     additionalNotes,
@@ -81,62 +52,4 @@ export const createProfile = async (req: AuthRequest, res: Response) => {
     message: "이력이 정상적으로 등록되었습니다.",
     data: null,
   });
-};
-
-// GPT 응답 생성 API
-export const generateGPTResponse = async (req: Request, res: Response) => {
-  const { id } = req.params; // URL 경로에서 id 추출
-
-  try {
-    // ObjectId로 변환
-    const profileId = new Types.ObjectId(id); // MongoDB에서 찾을 수 있도록 ObjectId로 변환
-
-    // 해당 이력 찾기, 로그인된 사용자와 매칭되는 데이터만
-    const profile = await UserProfile.findOne({
-      _id: profileId,
-      user: req.user!._id,
-    });
-
-    if (!profile) {
-      return res
-        .status(404)
-        .json({ code: 404, message: "이력을 찾을 수 없습니다.", data: null });
-    }
-    // 이미 추천받은 이력인지 확인
-    const existingRecommendation = await GptRecommendation.findOne({
-      user: req.user!._id,
-      profile: profile._id,
-    });
-
-    if (existingRecommendation) {
-      return res.status(400).json({
-        code: 400,
-        message: "이미 추천받은 이력입니다.",
-        data: {
-          recommendationId: existingRecommendation._id,
-          profileId: profile._id,
-        },
-      });
-    }
-
-    // GPT 호출 및 추천 결과 저장
-    const gptResponse = await getGPTResponse(profile);
-
-    const recommendation = await GptRecommendation.create({
-      user: req.user!._id,
-      profile: profile._id,
-      rankings: gptResponse.rankings,
-    });
-
-    res.status(200).json({
-      code: 200,
-      message: "GPT 응답 생성 성공",
-      data: { gptResponse, recommendationId: recommendation._id },
-    });
-  } catch (error) {
-    console.error(error);
-    res
-      .status(500)
-      .json({ code: 500, message: "GPT 응답 생성 실패", data: null });
-  }
 };

--- a/src/docs/countryRecommendationDocs.ts
+++ b/src/docs/countryRecommendationDocs.ts
@@ -1,0 +1,149 @@
+// Country Recommendation
+export const countryRecommendationSwaggerDocs = {
+  paths: {
+    "/api/country-recommendations/{profileId}": {
+      post: {
+        summary: "인증된 사용자의 특정 프로필 기반 국가 추천",
+        description:
+          "특정 프로필 ID로 국가 추천을 요청합니다. 중복 요청 시 기존 결과를 반환하며, 신규 추천 시 결과를 저장합니다.",
+        tags: ["Country Recommendations"],
+        security: [{ bearerAuth: [] }],
+        parameters: [
+          {
+            name: "profileId",
+            in: "path",
+            required: true,
+            schema: { type: "string" },
+            description: "추천을 받을 프로필 ID",
+          },
+        ],
+        requestBody: {
+          required: true,
+          content: {
+            "application/json": {
+              schema: {
+                type: "object",
+                properties: {
+                  language: {
+                    type: "string",
+                    enum: [
+                      "English",
+                      "Japanese",
+                      "Chinese",
+                      "German",
+                      "French",
+                      "Spanish",
+                      "Korean",
+                      "Other",
+                    ],
+                    example: "Korean",
+                  },
+                  expectedSalary: {
+                    type: "number",
+                    description: "희망 연봉 (USD)",
+                    example: 80000,
+                  },
+                  jobField: {
+                    type: "object",
+                    properties: {
+                      code: { type: "string", example: "2" },
+                      nameKo: { type: "string", example: "전문가" },
+                      nameEn: { type: "string", example: "Professionals" },
+                    },
+                    required: ["code", "nameKo", "nameEn"],
+                  },
+                  priorities: {
+                    type: "object",
+                    properties: {
+                      first: {
+                        type: "string",
+                        enum: ["language", "salary", "job"],
+                        example: "language",
+                      },
+                      second: {
+                        type: "string",
+                        enum: ["language", "salary", "job"],
+                        example: "salary",
+                      },
+                      third: {
+                        type: "string",
+                        enum: ["language", "salary", "job"],
+                        example: "job",
+                      },
+                    },
+                    required: ["first", "second", "third"],
+                  },
+                },
+                required: [
+                  "language",
+                  "expectedSalary",
+                  "jobField",
+                  "priorities",
+                ],
+              },
+            },
+          },
+        },
+        responses: {
+          200: {
+            description: "추천 완료 또는 기존 추천 결과 반환",
+            content: {
+              "application/json": {
+                schema: {
+                  type: "object",
+                  properties: {
+                    success: { type: "boolean", example: true },
+                    message: {
+                      type: "string",
+                      example: "국가 추천이 완료되고 저장되었습니다.",
+                    },
+                    data: {
+                      type: "object",
+                      properties: {
+                        isExisting: { type: "boolean", example: false },
+                        recommendationId: {
+                          type: "string",
+                          example: "660f62c89abf1b001c66e678",
+                        },
+                        profileId: {
+                          type: "string",
+                          example: "660f62c89abf1b001c66e678",
+                        },
+                        recommendations: {
+                          type: "array",
+                          items: {
+                            type: "object",
+                            properties: {
+                              rank: { type: "number", example: 1 },
+                              totalScore: { type: "number", example: 85.5 },
+                              country: {
+                                type: "object",
+                                properties: {
+                                  name: { type: "string", example: "싱가포르" },
+                                  code: { type: "string", example: "SGP" },
+                                },
+                              },
+                            },
+                          },
+                        },
+                        timestamp: {
+                          type: "string",
+                          format: "date-time",
+                          example: "2025-09-25T10:00:00Z",
+                        },
+                      },
+                    },
+                  },
+                },
+              },
+            },
+          },
+          400: { description: "잘못된 요청 데이터" },
+          401: { description: "인증 실패" },
+          404: { description: "프로필을 찾을 수 없음" },
+          500: { description: "서버 오류" },
+        },
+      },
+    },
+  },
+};

--- a/src/docs/guestDocs.ts
+++ b/src/docs/guestDocs.ts
@@ -1,61 +1,183 @@
-export const guestDocs = {
-  "/api/guest/recommend": {
-    post: {
-      tags: ["Guest"],
-      summary: "비회원 국가 추천",
-      description:
-        "비회원이 이력 정보를 입력하면 GPT가 적합한 국가 3곳을 추천합니다.",
-      requestBody: {
-        required: true,
-        content: {
-          "application/json": {
-            schema: {
-              type: "object",
-              properties: {
-                skills: {
-                  type: "string[]",
-                  example: ["React", "JavaScript", "HTML/CSS"],
-                },
-                languages: {
-                  type: "string[]",
-                  example: ["영어 중상", "한국어 원어민"],
-                },
-                desiredSalary: { type: "string", example: "연 4만 달러 이상" },
-                desiredJob: { type: "string", example: "웹 개발자" },
-                additionalNotes: {
-                  type: "string",
-                  example: "원격 근무 선호",
-                },
-              },
-              required: ["skills", "languages", "desiredSalary", "desiredJob"],
-            },
-          },
-        },
-      },
-      responses: {
-        200: {
-          description: "국가 추천 성공",
+// Guest Service
+export const guestSwaggerDocs = {
+  paths: {
+    "/api/guest/recommend": {
+      post: {
+        summary: "비회원 국가 추천",
+        description:
+          "비회원이 언어, 연봉, 직무, 우선순위를 입력하여 API 기반으로 국가 추천을 받습니다. 회원과 동일한 추천 알고리즘을 사용하지만 데이터베이스에 저장하지 않으며 시뮬레이션 기능은 제공하지 않습니다.",
+        tags: ["Guest"],
+        requestBody: {
+          required: true,
           content: {
             "application/json": {
               schema: {
                 type: "object",
                 properties: {
-                  code: { type: "integer", example: 200 },
-                  message: { type: "string", example: "국가 추천 완료" },
-                  data: {
+                  language: {
+                    type: "string",
+                    enum: [
+                      "English",
+                      "Japanese",
+                      "Chinese",
+                      "German",
+                      "French",
+                      "Spanish",
+                      "Korean",
+                      "Other",
+                    ],
+                    description: "사용 가능한 언어 (단일 선택)",
+                    example: "Korean",
+                  },
+                  expectedSalary: {
+                    type: "number",
+                    description: "희망 연봉 (USD)",
+                    minimum: 10000,
+                    maximum: 500000,
+                    example: 50000,
+                  },
+                  jobField: {
                     type: "object",
                     properties: {
-                      recommendedCountries: {
-                        type: "array",
-                        items: {
+                      code: {
+                        type: "string",
+                        enum: [
+                          "0",
+                          "1",
+                          "2",
+                          "3",
+                          "4",
+                          "5",
+                          "6",
+                          "7",
+                          "8",
+                          "9",
+                        ],
+                        description: "ISCO-08 대분류 코드",
+                        example: "2",
+                      },
+                      nameKo: {
+                        type: "string",
+                        description: "한국어 직무명",
+                        example: "전문가",
+                      },
+                    },
+                    required: ["code", "nameKo"],
+                  },
+                  priorities: {
+                    type: "object",
+                    properties: {
+                      first: {
+                        type: "string",
+                        enum: ["language", "salary", "job"],
+                        description: "1순위 우선사항 (가중치 0.5)",
+                        example: "salary",
+                      },
+                      second: {
+                        type: "string",
+                        enum: ["language", "salary", "job"],
+                        description: "2순위 우선사항 (가중치 0.3)",
+                        example: "language",
+                      },
+                      third: {
+                        type: "string",
+                        enum: ["language", "salary", "job"],
+                        description: "3순위 우선사항 (가중치 0.2)",
+                        example: "job",
+                      },
+                    },
+                    required: ["first", "second", "third"],
+                  },
+                },
+                required: [
+                  "language",
+                  "expectedSalary",
+                  "jobField",
+                  "priorities",
+                ],
+              },
+            },
+          },
+        },
+        responses: {
+          200: {
+            description: "국가 추천 성공",
+            content: {
+              "application/json": {
+                schema: {
+                  type: "object",
+                  properties: {
+                    success: {
+                      type: "boolean",
+                      example: true,
+                    },
+                    message: {
+                      type: "string",
+                      example: "비회원 국가 추천이 완료되었습니다.",
+                    },
+                    data: {
+                      type: "object",
+                      properties: {
+                        userProfile: {
                           type: "object",
-                          properties: {
-                            country: { type: "string", example: "캐나다" },
-                            reason: {
-                              type: "string",
-                              example: "다문화 환경과 IT 산업 수요가 높습니다.",
+                          description: "입력한 사용자 프로필",
+                        },
+                        recommendations: {
+                          type: "array",
+                          items: {
+                            type: "object",
+                            properties: {
+                              country: {
+                                type: "string",
+                                example: "Canada",
+                              },
+                              countryKo: {
+                                type: "string",
+                                example: "캐나다",
+                              },
+                              totalScore: {
+                                type: "number",
+                                example: 85.5,
+                              },
+                              reasons: {
+                                type: "array",
+                                items: {
+                                  type: "string",
+                                },
+                                example: [
+                                  "언어 점수가 높음",
+                                  "경제 지표가 우수함",
+                                ],
+                              },
                             },
                           },
+                        },
+                        appliedWeights: {
+                          type: "object",
+                          properties: {
+                            first: {
+                              type: "number",
+                              example: 0.5,
+                            },
+                            second: {
+                              type: "number",
+                              example: 0.3,
+                            },
+                            third: {
+                              type: "number",
+                              example: 0.2,
+                            },
+                          },
+                        },
+                        timestamp: {
+                          type: "string",
+                          format: "date-time",
+                          example: "2024-01-15T10:30:00.000Z",
+                        },
+                        note: {
+                          type: "string",
+                          example:
+                            "비회원은 국가 추천까지만 제공됩니다. 시뮬레이션 기능을 이용하려면 회원가입이 필요합니다.",
                         },
                       },
                     },
@@ -64,9 +186,46 @@ export const guestDocs = {
               },
             },
           },
-        },
-        500: {
-          description: "GPT 추천 실패",
+          400: {
+            description: "잘못된 요청 (입력 데이터 검증 실패)",
+            content: {
+              "application/json": {
+                schema: {
+                  type: "object",
+                  properties: {
+                    success: {
+                      type: "boolean",
+                      example: false,
+                    },
+                    message: {
+                      type: "string",
+                      example: "사용 가능한 언어를 1개 이상 입력해주세요.",
+                    },
+                  },
+                },
+              },
+            },
+          },
+          500: {
+            description: "서버 오류",
+            content: {
+              "application/json": {
+                schema: {
+                  type: "object",
+                  properties: {
+                    success: {
+                      type: "boolean",
+                      example: false,
+                    },
+                    message: {
+                      type: "string",
+                      example: "국가 추천 처리 중 서버 오류가 발생했습니다.",
+                    },
+                  },
+                },
+              },
+            },
+          },
         },
       },
     },

--- a/src/docs/mypageDocs.ts
+++ b/src/docs/mypageDocs.ts
@@ -281,8 +281,8 @@ export const mypageSwaggerDocs = {
 
     "/api/mypage/recommendations": {
       get: {
-        summary: "GPT 추천 결과 목록 조회",
-        description: "사용자가 저장한 GPT 추천 결과 리스트 반환",
+        summary: "API 기반 국가 추천 결과 목록 조회",
+        description: "사용자가 저장한 API 기반 국가 추천 결과 리스트 반환",
         tags: ["Mypage"],
         security: [{ bearerAuth: [] }],
         responses: {
@@ -291,92 +291,123 @@ export const mypageSwaggerDocs = {
             content: {
               "application/json": {
                 schema: {
-                  type: "array",
-                  items: {
-                    type: "object",
-                    properties: {
-                      _id: {
-                        type: "string",
-                        example: "660f62c89abf1b001c66e678",
-                      },
-                      profile: {
-                        type: "object",
-                        properties: {
-                          languages: {
-                            type: "array",
-                            items: {
-                              type: "object",
-                              properties: {
-                                language: {
-                                  type: "string",
-                                  example: "English",
-                                },
-                                level: { type: "string", example: "상급" },
-                              },
-                            },
-                            example: [
-                              { language: "Korean", level: "원어민" },
-                              { language: "Japanese", level: "중급" },
-                            ],
-                          },
-                          desiredSalary: {
-                            type: "string",
-                            example: "3천만 ~ 5천만",
-                          },
-                          desiredJob: {
-                            type: "object",
-                            properties: {
-                              mainCategory: { type: "string", example: "교육" },
-                              subCategory: {
-                                type: "string",
-                                example: "과외/튜터",
-                              },
-                            },
-                          },
-                          example: "없음",
-                        },
-                        additionalNotes: {
-                          type: "string",
-                          example: "아시아 국가 희망",
-                        },
-                      },
-                    },
-                    rankings: {
+                  type: "object",
+                  properties: {
+                    code: { type: "number", example: 200 },
+                    message: { type: "string", example: "추천 결과 조회 성공" },
+                    data: {
                       type: "array",
                       items: {
                         type: "object",
                         properties: {
-                          country: { type: "string" },
-                          job: { type: "string" },
-                          reason: { type: "string" },
+                          _id: {
+                            type: "string",
+                            example: "660f62c89abf1b001c66e678",
+                          },
+                          profile: {
+                            type: "object",
+                            properties: {
+                              language: {
+                                type: "string",
+                                example: "English",
+                              },
+                              desiredSalary: {
+                                type: "string",
+                                example: "3천만 ~ 5천만",
+                              },
+                              desiredJob: {
+                                type: "object",
+                                properties: {
+                                  mainCategory: {
+                                    type: "string",
+                                    example: "교육",
+                                  },
+                                  subCategory: {
+                                    type: "string",
+                                    example: "과외/튜터",
+                                  },
+                                },
+                              },
+                              additionalNotes: {
+                                type: "string",
+                                example: "아시아 국가 희망",
+                              },
+                            },
+                          },
+                          recommendations: {
+                            type: "array",
+                            items: {
+                              type: "object",
+                              properties: {
+                                country: {
+                                  type: "string",
+                                  example: "싱가포르",
+                                },
+                                score: { type: "number", example: 85.5 },
+                                rank: { type: "number", example: 1 },
+                                details: {
+                                  type: "object",
+                                  properties: {
+                                    economicScore: {
+                                      type: "number",
+                                      example: 90,
+                                    },
+                                    employmentScore: {
+                                      type: "number",
+                                      example: 85,
+                                    },
+                                    languageScore: {
+                                      type: "number",
+                                      example: 95,
+                                    },
+                                    salaryScore: {
+                                      type: "number",
+                                      example: 80,
+                                    },
+                                  },
+                                },
+                                economicData: {
+                                  type: "object",
+                                  properties: {
+                                    gdpPerCapita: {
+                                      type: "number",
+                                      example: 65000,
+                                    },
+                                    unemploymentRate: {
+                                      type: "number",
+                                      example: 3.2,
+                                    },
+                                    averageSalary: {
+                                      type: "number",
+                                      example: 55000,
+                                    },
+                                  },
+                                },
+                                countryInfo: {
+                                  type: "object",
+                                  properties: {
+                                    region: { type: "string", example: "Asia" },
+                                    languages: {
+                                      type: "array",
+                                      items: { type: "string" },
+                                      example: ["English", "Chinese", "Malay"],
+                                    },
+                                    population: {
+                                      type: "number",
+                                      example: 5900000,
+                                    },
+                                  },
+                                },
+                              },
+                            },
+                          },
+                          createdAt: {
+                            type: "string",
+                            format: "date-time",
+                            example: "2025-04-04T05:34:21.201Z",
+                          },
                         },
                       },
-                      example: [
-                        {
-                          country: "일본",
-                          job: "수학 교사",
-                          reason:
-                            "일본어 구사 가능하며, 학원에서의 수학 지도 경험이 있음",
-                        },
-                        {
-                          country: "싱가포르",
-                          job: "수학 튜터",
-                          reason:
-                            "싱가포르는 교육열이 높아 수학 튜터에 대한 수요가 많음",
-                        },
-                        {
-                          country: "중국",
-                          job: "국제학교 수학 선생님",
-                          reason:
-                            "중국의 국제학교에서는 외국인 선생님을 선호하며, 토익 점수와 학점이 높아 유리함",
-                        },
-                      ],
-                    },
-
-                    createdAt: {
-                      type: "string",
-                      format: "date-time",
-                      example: "2025-04-04T05:34:21.201Z",
                     },
                   },
                 },
@@ -536,8 +567,8 @@ export const mypageSwaggerDocs = {
 
   "/api/mypage/recommendations/by-profile/{profileId}": {
     get: {
-      summary: "특정 이력의 GPT 추천 결과 조회",
-      description: "해당 이력(profileId)에 대한 GPT 추천 결과 반환",
+      summary: "특정 이력의 API 기반 국가 추천 결과 조회",
+      description: "해당 이력(profileId)에 대한 API 기반 국가 추천 결과 반환",
       tags: ["Mypage"],
       security: [{ bearerAuth: [] }],
       parameters: [
@@ -557,43 +588,113 @@ export const mypageSwaggerDocs = {
               schema: {
                 type: "object",
                 properties: {
-                  _id: { type: "string", example: "663fa12345abcd..." },
-                  profile: {
-                    type: "object",
-                    properties: {
-                      languages: {
-                        type: "array",
-                        items: {
-                          type: "object",
-                          properties: {
-                            language: { type: "string" },
-                            level: { type: "string" },
-                          },
-                        },
-                      },
-                      desiredSalary: { type: "string" },
-                      desiredJob: {
-                        type: "object",
-                        properties: {
-                          mainCategory: { type: "string" },
-                          subCategory: { type: "string" },
-                        },
-                      },
-                      additionalNotes: { type: "string" },
-                    },
-                  },
-                  rankings: {
+                  code: { type: "number", example: 200 },
+                  message: { type: "string", example: "추천 결과 조회 성공" },
+                  data: {
                     type: "array",
                     items: {
                       type: "object",
                       properties: {
-                        country: { type: "string" },
-                        job: { type: "string" },
-                        reason: { type: "string" },
+                        _id: { type: "string", example: "663fa12345abcd..." },
+                        profile: {
+                          type: "object",
+                          properties: {
+                            language: {
+                              type: "string",
+                              example: "English",
+                            },
+                            desiredSalary: {
+                              type: "string",
+                              example: "3천만 ~ 5천만",
+                            },
+                            desiredJob: {
+                              type: "object",
+                              properties: {
+                                mainCategory: {
+                                  type: "string",
+                                  example: "교육",
+                                },
+                                subCategory: {
+                                  type: "string",
+                                  example: "과외/튜터",
+                                },
+                              },
+                            },
+                            additionalNotes: {
+                              type: "string",
+                              example: "아시아 국가 희망",
+                            },
+                          },
+                        },
+                        recommendations: {
+                          type: "array",
+                          items: {
+                            type: "object",
+                            properties: {
+                              country: { type: "string", example: "싱가포르" },
+                              score: { type: "number", example: 85.5 },
+                              rank: { type: "number", example: 1 },
+                              details: {
+                                type: "object",
+                                properties: {
+                                  economicScore: {
+                                    type: "number",
+                                    example: 90,
+                                  },
+                                  employmentScore: {
+                                    type: "number",
+                                    example: 85,
+                                  },
+                                  languageScore: {
+                                    type: "number",
+                                    example: 95,
+                                  },
+                                  salaryScore: { type: "number", example: 80 },
+                                },
+                              },
+                              economicData: {
+                                type: "object",
+                                properties: {
+                                  gdpPerCapita: {
+                                    type: "number",
+                                    example: 65000,
+                                  },
+                                  unemploymentRate: {
+                                    type: "number",
+                                    example: 3.2,
+                                  },
+                                  averageSalary: {
+                                    type: "number",
+                                    example: 55000,
+                                  },
+                                },
+                              },
+                              countryInfo: {
+                                type: "object",
+                                properties: {
+                                  region: { type: "string", example: "Asia" },
+                                  languages: {
+                                    type: "array",
+                                    items: { type: "string" },
+                                    example: ["English", "Chinese", "Malay"],
+                                  },
+                                  population: {
+                                    type: "number",
+                                    example: 5900000,
+                                  },
+                                },
+                              },
+                            },
+                          },
+                        },
+                        createdAt: {
+                          type: "string",
+                          format: "date-time",
+                          example: "2025-04-04T05:34:21.201Z",
+                        },
                       },
                     },
                   },
-                  createdAt: { type: "string", format: "date-time" },
                 },
               },
             },

--- a/src/docs/simulationDocs.ts
+++ b/src/docs/simulationDocs.ts
@@ -570,59 +570,6 @@ export const simulationSwaggerDocs = {
         },
       },
     },
-    "/api/simulation/scores/{simulationInputId}": {
-      get: {
-        summary: "취업 가능성과 이주 추천도 계산",
-        tags: ["Simulation"],
-        security: [{ bearerAuth: [] }],
-        parameters: [
-          {
-            name: "simulationInputId",
-            in: "path",
-            required: true,
-            schema: { type: "string" },
-            description: "SimulationInput ID (MongoDB ObjectId)",
-          },
-        ],
-        responses: {
-          200: {
-            description: "점수 계산 성공",
-            content: {
-              "application/json": {
-                schema: {
-                  type: "object",
-                  properties: {
-                    code: {
-                      type: "integer",
-                      example: 200,
-                    },
-                    message: {
-                      type: "string",
-                      example: "점수 계산 성공",
-                    },
-                    data: {
-                      type: "object",
-                      properties: {
-                        migrationSuitability: {
-                          type: "integer",
-                          example: 74,
-                        },
-                      },
-                    },
-                  },
-                },
-              },
-            },
-          },
-          404: {
-            description: "입력 정보 또는 사용자 이력 정보 없음",
-          },
-          500: {
-            description: "서버 오류",
-          },
-        },
-      },
-    },
 
     "/api/simulation/list": {
       get: {

--- a/src/docs/swaggerDocs.ts
+++ b/src/docs/swaggerDocs.ts
@@ -4,15 +4,17 @@ import { mypageSwaggerDocs } from "./mypageDocs";
 import { profileSwaggerDocs } from "./profileDocs";
 import { simulationSwaggerDocs } from "./simulationDocs";
 import { rankingSwaggerDocs } from "./rankingDocs";
-import { guestDocs } from "./guestDocs";
+import { guestSwaggerDocs } from "./guestDocs";
+import { countryRecommendationSwaggerDocs } from "./countryRecommendationDocs";
 
 export const swaggerDocs = {
   paths: {
     ...authSwaggerDocs.paths,
     ...profileSwaggerDocs.paths,
+    ...countryRecommendationSwaggerDocs.paths,
     ...simulationSwaggerDocs.paths,
     ...mypageSwaggerDocs.paths,
     ...rankingSwaggerDocs.paths,
-    ...guestDocs,
+    ...guestSwaggerDocs.paths,
   },
 };

--- a/src/middlewares/authMiddleware.ts
+++ b/src/middlewares/authMiddleware.ts
@@ -32,4 +32,28 @@ export const protect = async (
   }
 };
 
+// 선택적 JWT 인증 미들웨어 (토큰이 있으면 인증, 없으면 통과)
+export const optionalAuth = async (
+  req: AuthRequest,
+  res: Response,
+  next: NextFunction
+) => {
+  let token = req.headers.authorization;
+
+  if (token && token.startsWith("Bearer")) {
+    try {
+      const decoded: any = jwt.verify(
+        token.split(" ")[1],
+        process.env.JWT_SECRET!
+      );
+      req.user = await User.findById(decoded.id).select("-password");
+    } catch (error) {
+      // 토큰이 유효하지 않아도 계속 진행 (req.user는 undefined)
+      console.log("토큰 검증 실패, 비인증 상태로 진행:", error);
+    }
+  }
+  // 토큰이 없거나 유효하지 않아도 next() 호출
+  next();
+};
+
 export { AuthRequest };

--- a/src/models/UserProfile.ts
+++ b/src/models/UserProfile.ts
@@ -7,30 +7,21 @@ const userProfileSchema = new mongoose.Schema({
     required: true,
   },
 
-  // 언어 능력
-  languages: [
-    {
-      language: {
-        type: String,
-        enum: [
-          "English",
-          "Japanese",
-          "Chinese",
-          "German",
-          "French",
-          "Spanish",
-          "Korean",
-          "Other",
-        ],
-        required: true,
-      },
-      level: {
-        type: String,
-        enum: ["원어민", "상급", "중급", "초급", "없음"],
-        required: true,
-      },
-    },
-  ],
+  // 언어 능력 (단일 언어 선택)
+  language: {
+    type: String,
+    enum: [
+      "English",
+      "Japanese",
+      "Chinese",
+      "German",
+      "French",
+      "Spanish",
+      "Korean",
+      "Other",
+    ],
+    required: true,
+  },
 
   // 희망 연봉
   desiredSalary: {

--- a/src/models/countryRecommendationResult.ts
+++ b/src/models/countryRecommendationResult.ts
@@ -1,0 +1,41 @@
+import mongoose from "mongoose";
+
+const CountryRecommendationResultSchema = new mongoose.Schema(
+  {
+    user: { type: mongoose.Schema.Types.ObjectId, ref: "User", required: true },
+    profile: {
+      type: mongoose.Schema.Types.ObjectId,
+      ref: "UserProfile",
+      required: true,
+    },
+    recommendations: [
+      {
+        country: { type: String, required: true },
+        score: { type: Number, required: true },
+        rank: { type: Number, required: true },
+        details: {
+          economicScore: { type: Number, required: true },
+          employmentScore: { type: Number, required: true },
+          languageScore: { type: Number, required: true },
+          salaryScore: { type: Number, required: true },
+        },
+        economicData: {
+          gdpPerCapita: { type: Number },
+          employmentRate: { type: Number },
+          averageSalary: { type: Number },
+        },
+        countryInfo: {
+          region: { type: String },
+          languages: [{ type: String }],
+          population: { type: Number },
+        },
+      },
+    ],
+  },
+  { timestamps: true }
+);
+
+export default mongoose.model(
+  "CountryRecommendationResult",
+  CountryRecommendationResultSchema
+);

--- a/src/routes/countryRecommendationRoutes.ts
+++ b/src/routes/countryRecommendationRoutes.ts
@@ -1,0 +1,13 @@
+import { Router } from "express";
+import { getCountryRecommendations } from "../controllers/countryRecommendationController";
+import { protect } from "../middlewares/authMiddleware";
+
+const router = Router();
+
+/**
+ * POST /api/country-recommendations/:profileId
+ * 인증된 사용자의 특정 프로필 기반 국가 추천 (중복 체크 및 저장)
+ */
+router.post("/:profileId", protect, getCountryRecommendations);
+
+export default router;

--- a/src/routes/guestRoutes.ts
+++ b/src/routes/guestRoutes.ts
@@ -1,9 +1,17 @@
-import { Router } from "express";
-import { recommendCountriesForGuest } from "../controllers/guestController";
-import { asyncHandler } from "../utils/asyncHandler";
+import express from "express";
+import {
+  getGuestCountryRecommendations,
+  deprecatedNotice,
+} from "../controllers/guestController";
 
-const router = Router();
+const router = express.Router();
 
-// 비회원 이력 정보 입력 후 GPT 기반 국가 3개 추천
-router.post("/recommend", asyncHandler(recommendCountriesForGuest));
+// 비회원 국가 추천 엔드포인트
+router.post("/recommend", getGuestCountryRecommendations);
+
+// 기존 GPT 기반 엔드포인트들 - 더 이상 사용되지 않음
+router.post("/profile", deprecatedNotice);
+router.post("/migrate", deprecatedNotice);
+router.get("/migrate/:id", deprecatedNotice);
+
 export default router;

--- a/src/routes/mypageRoutes.ts
+++ b/src/routes/mypageRoutes.ts
@@ -3,9 +3,9 @@ import {
   getUserInfo,
   updateUserInfo,
   deleteUser,
-  getGptRecommendations,
-  getGptRecommendationByProfileId,
   getSimulationsByProfileId,
+  getUserRecommendations,
+  getRecommendationsByProfileId,
 } from "../controllers/mypageController";
 import {
   getProfile,
@@ -37,8 +37,6 @@ router.put("/profiles/:id", protect, asyncHandler(updateProfile));
 // 사용자 이력 삭제 (DELETE /api/profile/:id)
 router.delete("/profiles/:id", protect, asyncHandler(deleteProfile));
 
-// GPT 추천 결과 조회
-router.get("/recommendations", protect, asyncHandler(getGptRecommendations));
 // 시뮬레이션 전 추가 정보 조회
 router.get(
   "/simulations/inputs",
@@ -48,16 +46,21 @@ router.get(
 // 시뮬레이션 결과 조회
 router.get("/simulations", protect, asyncHandler(getUserSimulations));
 
-// 특정 이력별 GPT 추천 결과 조회 API
-router.get(
-  "/recommendations/by-profile/:profileId",
-  protect,
-  asyncHandler(getGptRecommendationByProfileId)
-);
 // 특정 이력별 시뮬레이션 결과 조회 API
 router.get(
   "/simulations/by-profile/:profileId",
   protect,
   asyncHandler(getSimulationsByProfileId)
 );
+
+// API 기반 국가 추천 결과 조회 API
+router.get("/recommendations", protect, asyncHandler(getUserRecommendations));
+
+// 특정 이력별 API 기반 국가 추천 결과 조회 API
+router.get(
+  "/recommendations/by-profile/:profileId",
+  protect,
+  asyncHandler(getRecommendationsByProfileId)
+);
+
 export default router;

--- a/src/routes/profileRoutes.ts
+++ b/src/routes/profileRoutes.ts
@@ -3,14 +3,10 @@ import express from "express";
 import { protect } from "../middlewares/authMiddleware";
 import { asyncHandler } from "../utils/asyncHandler";
 import { createProfile } from "../controllers/profileController";
-import { generateGPTResponse } from "../controllers/profileController";
 
 const router = express.Router();
 
 // 사용자 이력 등록 (POST /api/profile)
 router.post("/", protect, asyncHandler(createProfile));
-
-// GPT 추천 생성
-router.post("/:id/gpt", protect, asyncHandler(generateGPTResponse));
 
 export default router;

--- a/src/routes/simulationRoutes.ts
+++ b/src/routes/simulationRoutes.ts
@@ -7,7 +7,6 @@ import {
   recommendCities,
 } from "../controllers/simulationController";
 import { getSimulationFlightLinks } from "../controllers/simulationController";
-import { calculateSimulationScores } from "../controllers/simulationController";
 import { getSimulationList } from "../controllers/simulationController";
 
 const router = express.Router();
@@ -18,12 +17,8 @@ router.post("/:id/gpt", protect, asyncHandler(generateAndSaveSimulation));
 // 도시 3개 추천
 router.post("/:id/cities", protect, asyncHandler(recommendCities));
 
-// 추가 정보 입력
-router.post(
-  "/:recommendationId/:profileId",
-  protect,
-  asyncHandler(saveSimulationInput)
-);
+// 추가 정보 입력 (GPT 추천 대신 직접 국가 선택 방식으로 변경)
+router.post("/:profileId", protect, asyncHandler(saveSimulationInput));
 
 // 항공권 링크 포함 시뮬레이션 결과 조회
 router.get(
@@ -31,12 +26,7 @@ router.get(
   protect,
   asyncHandler(getSimulationFlightLinks)
 );
-// 취업 가능성 및 이주 추천도
-router.get(
-  "/scores/:simulationInputId",
-  protect,
-  asyncHandler(calculateSimulationScores)
-);
+
 // 시뮬레이션 요약 보기
 router.get("/:simulationId", protect, asyncHandler(getSimulationList));
 

--- a/src/services/countryRecommendationService.ts
+++ b/src/services/countryRecommendationService.ts
@@ -1,0 +1,447 @@
+import {
+  UserCareerProfile,
+  CountryData,
+  ScoredCountry,
+  CountryRecommendation,
+} from "../types/countryRecommendation";
+import { ExternalAPIService } from "./externalAPIService";
+
+export class CountryRecommendationService {
+  // 가중치 상수
+  private static readonly PRIORITY_WEIGHTS = {
+    first: 0.5, // 1순위
+    second: 0.3, // 2순위
+    third: 0.2, // 3순위
+  };
+
+  // 메인 추천 로직
+  static async getTopCountryRecommendations(
+    userProfile: UserCareerProfile
+  ): Promise<CountryRecommendation[]> {
+    try {
+      console.log("국가 데이터 수집 시작...");
+
+      // 1. 외부 API에서 모든 국가 데이터 수집
+      const allCountries = await ExternalAPIService.getAllCountryData();
+      console.log(`총 ${allCountries.length}개 국가 데이터 수집 완료`);
+
+      // 2. 각 국가별 점수 계산
+      const scoredCountries = this.calculateCountryScores(
+        allCountries,
+        userProfile
+      );
+
+      // 3. 가중치 적용하여 최종 점수 계산
+      const weightedCountries = this.applyWeights(
+        scoredCountries,
+        userProfile.priorities
+      );
+
+      // 4. 상위 3개 국가 선별
+      const topCountries = this.selectTopCountries(weightedCountries, 3);
+
+      // 5. 추천 결과 포맷팅
+      return this.formatRecommendations(topCountries, userProfile);
+    } catch (error) {
+      console.error("국가 추천 처리 중 오류:", error);
+      throw new Error("국가 추천을 처리하는 중 오류가 발생했습니다.");
+    }
+  }
+
+  // 각 국가별 개별 점수 계산
+  private static calculateCountryScores(
+    countries: CountryData[],
+    userProfile: UserCareerProfile
+  ): ScoredCountry[] {
+    return countries.map((country) => {
+      const languageScore = this.calculateLanguageScore(
+        country,
+        userProfile.language
+      );
+      const salaryScore = this.calculateSalaryScore(
+        country,
+        userProfile.expectedSalary
+      );
+      const jobScore = this.calculateJobScore(country, userProfile.jobField);
+
+      return {
+        country,
+        scores: {
+          languageScore,
+          salaryScore,
+          jobScore,
+        },
+        weightedScore: 0, // 나중에 계산
+      };
+    });
+  }
+
+  // 언어 적합도 점수 계산 (0-100)
+  private static calculateLanguageScore(
+    country: CountryData,
+    userLanguage: string
+  ): number {
+    if (!country.languages || country.languages.length === 0) {
+      return 0;
+    }
+
+    // 사용자 언어와 국가 언어의 매칭 확인
+    const hasMatchingLanguage = country.languages.some(
+      (countryLang) =>
+        countryLang.toLowerCase().includes(userLanguage.toLowerCase()) ||
+        userLanguage.toLowerCase().includes(countryLang.toLowerCase())
+    );
+
+    if (hasMatchingLanguage) {
+      return 100; // 완전 매칭
+    }
+
+    // 영어 사용 국가인 경우 기본 점수 제공 (사용자 언어가 영어가 아닌 경우)
+    if (userLanguage.toLowerCase() !== "english") {
+      const hasEnglish = country.languages.some((lang) =>
+        lang.toLowerCase().includes("english")
+      );
+      return hasEnglish ? 30 : 10;
+    }
+
+    return 0; // 매칭되지 않는 경우
+  }
+
+  // 연봉 적합도 점수 계산 (0-100)
+  private static calculateSalaryScore(
+    country: CountryData,
+    expectedSalary: number
+  ): number {
+    if (!country.gdpPerCapita) {
+      return 30; // 데이터 없는 경우 중간 점수
+    }
+
+    // GDP per capita를 기준으로 예상 연봉 추정
+    // 일반적으로 GDP per capita의 1.5-2배가 평균 연봉
+    const estimatedAverageSalary = country.gdpPerCapita * 1.75;
+
+    // GDP per capita를 기반으로 한 연봉 추정
+    const adjustedSalary = estimatedAverageSalary;
+
+    // 기대 연봉 대비 점수 계산
+    if (adjustedSalary >= expectedSalary) {
+      return 100;
+    } else {
+      return Math.max(10, (adjustedSalary / expectedSalary) * 100);
+    }
+  }
+
+  // 직무 기회 점수 계산 (0-100)
+  private static calculateJobScore(
+    country: CountryData,
+    jobField: any
+  ): number {
+    let baseScore = 50;
+
+    // 고용률이 높을수록 높은 점수 (고용률은 보통 40-80% 범위)
+    if (country.employmentRate !== undefined) {
+      // 고용률을 0-100 점수로 변환 (50% 이상이면 좋은 편)
+      const employmentScore = Math.min(
+        100,
+        Math.max(0, (country.employmentRate - 40) * 2)
+      );
+      baseScore = (baseScore + employmentScore) / 2;
+    }
+
+    // 선진국/기술 선진국 가산점
+    const developedCountries = [
+      "USA",
+      "CAN",
+      "GBR",
+      "DEU",
+      "FRA",
+      "JPN",
+      "KOR",
+      "AUS",
+      "NZL",
+      "SGP",
+      "CHE",
+      "NLD",
+      "SWE",
+      "NOR",
+      "DNK",
+      "FIN",
+    ];
+
+    if (developedCountries.includes(country.code)) {
+      baseScore += 20;
+    }
+
+    // ISCO 코드별 추가 점수 (국가별 특화 분야)
+    const jobFieldBonus = this.getJobFieldBonus(country.code, jobField.code);
+    baseScore += jobFieldBonus;
+
+    return Math.min(100, Math.max(0, baseScore));
+  }
+
+  // ISCO-08 코드별 직무 분야 보너스 점수
+  private static getJobFieldBonus(
+    countryCode: string,
+    iscoCode: string
+  ): number {
+    // ISCO-08 대분류별 국가 특화 점수
+    const iscoJobFieldMap: {
+      [iscoCode: string]: { [country: string]: number };
+    } = {
+      "1": {
+        // 관리자
+        USA: 25,
+        GBR: 20,
+        CAN: 20,
+        AUS: 18,
+        CHE: 22,
+        SGP: 20,
+        HKG: 18,
+        DEU: 18,
+        FRA: 15,
+        NLD: 15,
+      },
+      "2": {
+        // 전문가 (의사, 변호사, 교수, 엔지니어 등)
+        USA: 25,
+        GBR: 22,
+        CAN: 20,
+        DEU: 22,
+        CHE: 25,
+        AUS: 18,
+        NLD: 20,
+        SWE: 20,
+        NOR: 18,
+        DNK: 18,
+        JPN: 15,
+        KOR: 15,
+        FRA: 18,
+        SGP: 20,
+      },
+      "3": {
+        // 기술자 및 준전문가
+        DEU: 25,
+        CHE: 20,
+        JPN: 22,
+        KOR: 20,
+        USA: 18,
+        CAN: 15,
+        AUS: 15,
+        SGP: 18,
+        NLD: 18,
+        SWE: 15,
+      },
+      "4": {
+        // 사무종사자
+        SGP: 18,
+        HKG: 15,
+        USA: 15,
+        GBR: 12,
+        CAN: 12,
+        AUS: 10,
+        JPN: 12,
+        KOR: 10,
+        DEU: 10,
+        FRA: 10,
+      },
+      "5": {
+        // 서비스 및 판매 종사자
+        USA: 20,
+        GBR: 15,
+        CAN: 15,
+        AUS: 15,
+        SGP: 12,
+        JPN: 10,
+        KOR: 8,
+        FRA: 12,
+        ITA: 10,
+        ESP: 8,
+      },
+      "6": {
+        // 농림어업 숙련 종사자
+        AUS: 20,
+        NZL: 25,
+        CAN: 18,
+        USA: 15,
+        NOR: 15,
+        DNK: 12,
+        NLD: 10,
+        FRA: 8,
+        ESP: 10,
+        ITA: 8,
+      },
+      "7": {
+        // 기능원 및 관련 기능 종사자
+        DEU: 25,
+        CHE: 22,
+        AUT: 20,
+        CAN: 18,
+        AUS: 18,
+        USA: 15,
+        JPN: 15,
+        KOR: 12,
+        NLD: 15,
+        SWE: 15,
+      },
+      "8": {
+        // 설비·기계 조작 및 조립 종사자
+        DEU: 22,
+        JPN: 20,
+        KOR: 18,
+        USA: 18,
+        CAN: 15,
+        CHE: 15,
+        AUT: 15,
+        SWE: 12,
+        NLD: 12,
+        CZE: 10,
+      },
+      "9": {
+        // 단순노무 종사자
+        USA: 10,
+        CAN: 8,
+        AUS: 8,
+        GBR: 6,
+        DEU: 6,
+        SGP: 8,
+        JPN: 5,
+        KOR: 5,
+        FRA: 6,
+        ITA: 5,
+      },
+      "0": {
+        // 군인
+        USA: 15,
+        KOR: 12,
+        GBR: 10,
+        FRA: 8,
+        DEU: 6,
+        CAN: 8,
+        AUS: 8,
+        SGP: 8,
+        JPN: 5,
+        ITA: 5,
+      },
+    };
+
+    return iscoJobFieldMap[iscoCode]?.[countryCode] || 0;
+  }
+
+  // 우선순위별 가중치 적용
+  private static applyWeights(
+    scoredCountries: ScoredCountry[],
+    priorities: { first: string; second: string; third: string }
+  ): ScoredCountry[] {
+    return scoredCountries.map((scored) => {
+      const scores = scored.scores;
+      let weightedScore = 0;
+
+      // 1순위, 2순위, 3순위에 따른 가중치 적용
+      const scoreMap = {
+        language: scores.languageScore,
+        salary: scores.salaryScore,
+        job: scores.jobScore,
+      };
+
+      weightedScore +=
+        (scoreMap as any)[priorities.first] * this.PRIORITY_WEIGHTS.first;
+      weightedScore +=
+        (scoreMap as any)[priorities.second] * this.PRIORITY_WEIGHTS.second;
+      weightedScore +=
+        (scoreMap as any)[priorities.third] * this.PRIORITY_WEIGHTS.third;
+
+      return {
+        ...scored,
+        weightedScore,
+      };
+    });
+  }
+
+  // 상위 N개 국가 선별
+  private static selectTopCountries(
+    weightedCountries: ScoredCountry[],
+    count: number
+  ): ScoredCountry[] {
+    return weightedCountries
+      .sort((a, b) => b.weightedScore - a.weightedScore)
+      .slice(0, count);
+  }
+
+  // 최종 추천 결과 포맷팅
+  private static formatRecommendations(
+    topCountries: ScoredCountry[],
+    userProfile: UserCareerProfile
+  ): CountryRecommendation[] {
+    return topCountries.map((scored, index) => {
+      const { first, second, third } = userProfile.priorities;
+      const appliedWeights = {
+        language: 0,
+        salary: 0,
+        job: 0,
+      };
+
+      // 적용된 가중치 계산
+      (appliedWeights as any)[first] = this.PRIORITY_WEIGHTS.first;
+      (appliedWeights as any)[second] = this.PRIORITY_WEIGHTS.second;
+      (appliedWeights as any)[third] = this.PRIORITY_WEIGHTS.third;
+
+      return {
+        rank: index + 1,
+        country: scored.country,
+        totalScore: Math.round(scored.weightedScore * 100) / 100,
+        breakdown: {
+          languageScore: Math.round(scored.scores.languageScore * 100) / 100,
+          salaryScore: Math.round(scored.scores.salaryScore * 100) / 100,
+          jobScore: Math.round(scored.scores.jobScore * 100) / 100,
+          appliedWeights,
+        },
+        reasons: this.generateReasons(scored, userProfile),
+      };
+    });
+  }
+
+  // 추천 이유 생성
+  private static generateReasons(
+    scored: ScoredCountry,
+    userProfile: UserCareerProfile
+  ): string[] {
+    const reasons: string[] = [];
+    const { country, scores } = scored;
+
+    // 언어 관련 이유
+    if (scores.languageScore > 70) {
+      reasons.push(
+        `사용 가능한 언어와 높은 호환성 (${Math.round(scores.languageScore)}점)`
+      );
+    } else if (scores.languageScore > 30) {
+      reasons.push("영어 사용 가능 국가로 의사소통 가능");
+    }
+
+    // 연봉 관련 이유
+    if (scores.salaryScore > 80) {
+      reasons.push(
+        `희망 연봉 달성 가능성 높음 (${Math.round(scores.salaryScore)}점)`
+      );
+    } else if (scores.salaryScore > 60) {
+      reasons.push("합리적인 연봉 수준 기대 가능");
+    }
+
+    // 직무 관련 이유
+    if (scores.jobScore > 75) {
+      reasons.push(`${userProfile.jobField.nameKo} 분야 취업 기회 풍부`);
+    } else if (scores.jobScore > 60) {
+      reasons.push("안정적인 고용 시장");
+    }
+
+    // 추가 정보
+    if (country.gdpPerCapita && country.gdpPerCapita > 40000) {
+      reasons.push("높은 경제 수준");
+    }
+
+    if (country.employmentRate && country.employmentRate > 65) {
+      reasons.push("높은 고용률");
+    }
+
+    return reasons.length > 0 ? reasons : ["종합적인 생활 환경 고려"];
+  }
+}

--- a/src/services/externalAPIService.ts
+++ b/src/services/externalAPIService.ts
@@ -1,0 +1,312 @@
+import axios from "axios";
+import { CountryData } from "../types/countryRecommendation";
+
+interface WorldBankIndicator {
+  indicator: { id: string; value: string };
+  country: { id: string; value: string };
+  countryiso3code: string;
+  date: string;
+  value: number | null;
+  unit: string;
+  obs_status: string;
+  decimal: number;
+}
+
+interface ILOSTATData {
+  ref_area: { label: string };
+  indicator: { label: string };
+  obs_value: number;
+  time: string;
+}
+
+export class ExternalAPIService {
+  private static readonly REST_COUNTRIES_API = "https://restcountries.com/v3.1";
+  private static readonly WORLD_BANK_API = "https://api.worldbank.org/v2";
+  private static readonly ILOSTAT_API =
+    "https://rplumber.ilo.org/data/indicator";
+
+  // REST Countries API에서 기본 국가 정보 가져오기
+  static async getCountriesBasicInfo(): Promise<CountryData[]> {
+    try {
+      console.log("REST Countries API 호출 시작...");
+
+      // 필요한 필드들을 명시하여 API 호출
+      const fields = "name,cca3,region,languages,population";
+      const response = await axios.get(
+        `${this.REST_COUNTRIES_API}/all?fields=${fields}`,
+        {
+          timeout: 10000, // 10초 타임아웃
+          headers: {
+            "User-Agent": "GloPick-Backend/1.0.0",
+            Accept: "application/json",
+          },
+        }
+      );
+
+      console.log(
+        `REST Countries API 응답: ${response.status}, 데이터 수: ${response.data.length}`
+      );
+
+      const filteredCountries = response.data
+        .filter(
+          (country: any) =>
+            country.name?.common &&
+            country.cca3 &&
+            country.region &&
+            country.population > 1000000 // 인구 100만 이상 국가만
+        )
+        .map((country: any) => ({
+          name: country.name.common,
+          code: country.cca3,
+          region: country.region,
+          languages: country.languages ? Object.values(country.languages) : [],
+          population: country.population,
+        }));
+
+      console.log(`필터링된 국가 수: ${filteredCountries.length}`);
+      console.log("✅ REST Countries API 데이터 수집 완료");
+      return filteredCountries;
+    } catch (error: any) {
+      console.error("REST Countries API 호출 실패:", {
+        message: error.message,
+        status: error.response?.status,
+        statusText: error.response?.statusText,
+        data: error.response?.data,
+      });
+
+      throw error;
+    }
+  }
+
+  // World Bank API에서 경제 데이터 가져오기 (GDP per capita)
+  static async getEconomicData(
+    countryCodes: string[]
+  ): Promise<Map<string, number>> {
+    const economicData = new Map<string, number>();
+
+    try {
+      // 최신 연도부터 5년치 데이터 요청
+      const currentYear = new Date().getFullYear();
+      const years = `${currentYear - 4}:${currentYear}`;
+
+      const response = await axios.get(
+        `${this.WORLD_BANK_API}/country/${countryCodes.join(
+          ";"
+        )}/indicator/NY.GDP.PCAP.CD`,
+        {
+          params: {
+            format: "json",
+            date: years,
+            per_page: 1000,
+          },
+        }
+      );
+
+      if (response.data && response.data[1]) {
+        response.data[1].forEach((item: WorldBankIndicator) => {
+          if (item.value !== null && item.countryiso3code) {
+            // 최신 데이터로 업데이트 (같은 국가의 경우 더 최신 데이터가 우선)
+            const existing = economicData.get(item.countryiso3code);
+            if (!existing || parseInt(item.date) > parseInt(item.date)) {
+              economicData.set(item.countryiso3code, item.value);
+            }
+          }
+        });
+      }
+
+      console.log("✅ World Bank API 데이터 수집 완료");
+      return economicData;
+    } catch (error) {
+      console.error("World Bank API 호출 실패:", error);
+      return economicData; // 빈 맵이라도 반환
+    }
+  }
+
+  // ILOSTAT API에서 고용 데이터 가져오기 (고용률)
+  static async getEmploymentData(
+    countryCodes: string[]
+  ): Promise<Map<string, number>> {
+    const employmentData = new Map<string, number>();
+
+    try {
+      console.log("ILOSTAT API 호출 시작...");
+
+      // ILOSTAT API: EMP_DWAP_SEX_AGE_RT_A (고용률 지표)
+      const response = await axios.get(
+        `${this.ILOSTAT_API}/?id=EMP_DWAP_SEX_AGE_RT_A&type=label&format=.csv&lang=en`,
+        {
+          timeout: 15000,
+          headers: {
+            "User-Agent": "GloPick-Backend/1.0.0",
+            Accept: "text/csv",
+          },
+        }
+      );
+
+      console.log(`ILOSTAT API 응답: ${response.status}`);
+
+      // CSV 데이터 파싱 (견고한 파싱)
+      if (!response.data || typeof response.data !== "string") {
+        console.warn("ILOSTAT API 응답 데이터가 올바르지 않습니다");
+        return employmentData;
+      }
+
+      const lines = response.data.split("\n").filter((line) => line.trim());
+      if (lines.length < 2) {
+        console.warn("ILOSTAT CSV 데이터가 충분하지 않습니다");
+        return employmentData;
+      }
+
+      const headers = lines[0]
+        .split(",")
+        .map((h) => h.replace(/"/g, "").trim());
+
+      // 국가명과 고용률 컬럼 찾기
+      const countryIndex = headers.findIndex(
+        (h: string) =>
+          h.toLowerCase().includes("country") ||
+          h.toLowerCase().includes("ref_area")
+      );
+      const valueIndex = headers.findIndex(
+        (h: string) =>
+          h.toLowerCase().includes("obs_value") ||
+          h.toLowerCase().includes("value")
+      );
+      const timeIndex = headers.findIndex(
+        (h: string) =>
+          h.toLowerCase().includes("time") || h.toLowerCase().includes("year")
+      );
+
+      if (countryIndex === -1 || valueIndex === -1) {
+        console.warn("ILOSTAT CSV 구조를 파싱할 수 없습니다");
+        console.log("Available headers:", headers);
+        return employmentData;
+      }
+
+      console.log(
+        `CSV 파싱: country=${countryIndex}, value=${valueIndex}, time=${timeIndex}`
+      );
+
+      // 최신 데이터만 사용 (2018년 이후로 범위 확대)
+      for (let i = 1; i < lines.length; i++) {
+        const line = lines[i];
+        if (!line.trim()) continue;
+
+        try {
+          const columns = line
+            .split(",")
+            .map((col) => col.replace(/"/g, "").trim());
+          if (
+            columns.length <= Math.max(countryIndex, valueIndex, timeIndex || 0)
+          )
+            continue;
+
+          const countryName = columns[countryIndex];
+          const employmentRateStr = columns[valueIndex];
+          const yearStr = timeIndex >= 0 ? columns[timeIndex] : "";
+
+          if (!countryName || !employmentRateStr) continue;
+
+          const employmentRate = parseFloat(employmentRateStr);
+          const year = yearStr ? parseInt(yearStr) : 2023; // 기본값
+
+          if (!countryName || isNaN(employmentRate) || year < 2018) continue;
+
+          // 국가명을 ISO 코드로 매핑
+          const countryCode = this.getCountryCodeFromName(countryName);
+          if (countryCode && countryCodes.includes(countryCode)) {
+            // 최신 데이터만 유지
+            if (!employmentData.has(countryCode) || year > 2020) {
+              employmentData.set(countryCode, employmentRate);
+            }
+          }
+        } catch (lineError) {
+          // 개별 라인 파싱 오류는 무시하고 계속 진행
+          continue;
+        }
+      }
+
+      console.log(
+        `ILOSTAT에서 ${employmentData.size}개국 고용률 데이터 수집 완료`
+      );
+      console.log("✅ ILOSTAT API 데이터 수집 완료");
+      return employmentData;
+    } catch (error) {
+      console.error("ILOSTAT API 호출 실패:", error);
+      return employmentData; // 에러 발생해도 빈 맵 반환
+    }
+  }
+
+  // 국가명을 ISO 코드로 매핑하는 헬퍼 함수
+  private static getCountryCodeFromName(countryName: string): string | null {
+    const countryMapping: { [key: string]: string } = {
+      "United States": "USA",
+      "United States of America": "USA",
+      Canada: "CAN",
+      "United Kingdom": "GBR",
+      Germany: "DEU",
+      France: "FRA",
+      Japan: "JPN",
+      Korea: "KOR",
+      "Republic of Korea": "KOR",
+      "South Korea": "KOR",
+      Australia: "AUS",
+      "New Zealand": "NZL",
+      Singapore: "SGP",
+      Switzerland: "CHE",
+      Netherlands: "NLD",
+      Sweden: "SWE",
+      Norway: "NOR",
+      Denmark: "DNK",
+      Finland: "FIN",
+      Austria: "AUT",
+      Belgium: "BEL",
+      Ireland: "IRL",
+      Spain: "ESP",
+      Italy: "ITA",
+      Portugal: "PRT",
+      Greece: "GRC",
+      "Czech Republic": "CZE",
+      Czechia: "CZE",
+      Poland: "POL",
+      Hungary: "HUN",
+      Slovakia: "SVK",
+      Slovenia: "SVN",
+      Estonia: "EST",
+      Latvia: "LVA",
+      Lithuania: "LTU",
+      Iceland: "ISL",
+      Luxembourg: "LUX",
+      Malta: "MLT",
+    };
+
+    return countryMapping[countryName] || null;
+  }
+
+  // 모든 외부 API 데이터를 한번에 수집 (REST Countries + World Bank + ILOSTAT)
+  static async getAllCountryData(): Promise<CountryData[]> {
+    try {
+      console.log("국가 기본 정보 수집 중...");
+      const countries = await this.getCountriesBasicInfo();
+      const countryCodes = countries.map((c) => c.code);
+
+      console.log(`${countries.length}개 국가 데이터 수집 중...`);
+
+      // 병렬로 외부 API 호출 (REST Countries + World Bank + ILOSTAT)
+      const [economicData, employmentData] = await Promise.all([
+        this.getEconomicData(countryCodes),
+        this.getEmploymentData(countryCodes),
+      ]);
+
+      // 데이터 병합
+      return countries.map((country) => ({
+        ...country,
+        gdpPerCapita: economicData.get(country.code),
+        employmentRate: employmentData.get(country.code),
+      }));
+    } catch (error) {
+      console.error("외부 API 데이터 수집 실패:", error);
+      throw error;
+    }
+  }
+}

--- a/src/types/countryRecommendation.ts
+++ b/src/types/countryRecommendation.ts
@@ -1,0 +1,60 @@
+// 사용자 입력 데이터 타입
+export interface UserCareerProfile {
+  language: string; // 사용 가능 언어 (단일 선택)
+  expectedSalary: number; // 희망 연봉 (USD)
+  jobField: ISCOJobField; // ISCO-08 기준 직무 분야
+  priorities: UserPriorities; // 우선순위
+}
+
+// ISCO-08 직무 분류
+export interface ISCOJobField {
+  code: string; // ISCO-08 대분류 코드 ('1'-'9', '0')
+  nameKo: string; // 한국어 직무명
+  nameEn: string; // 영어 직무명
+}
+
+export interface UserPriorities {
+  first: "language" | "salary" | "job"; // 1순위 (가중치 0.5)
+  second: "language" | "salary" | "job"; // 2순위 (가중치 0.3)
+  third: "language" | "salary" | "job"; // 3순위 (가중치 0.2)
+}
+
+// 국가 데이터 타입
+export interface CountryData {
+  name: string;
+  code: string;
+  region: string;
+  languages: string[];
+  gdpPerCapita?: number; // World Bank API에서 가져올 데이터
+  employmentRate?: number; // ILOSTAT API에서 가져올 데이터 (고용률)
+  population?: number;
+}
+
+// 점수가 계산된 국가 데이터
+export interface ScoredCountry {
+  country: CountryData;
+  scores: {
+    languageScore: number; // 언어 적합도 점수 (0-100)
+    salaryScore: number; // 연봉 적합도 점수 (0-100)
+    jobScore: number; // 직무 기회 점수 (0-100)
+  };
+  weightedScore: number; // 가중치 적용된 최종 점수
+}
+
+// 최종 추천 결과
+export interface CountryRecommendation {
+  rank: number;
+  country: CountryData;
+  totalScore: number;
+  breakdown: {
+    languageScore: number;
+    salaryScore: number;
+    jobScore: number;
+    appliedWeights: {
+      language: number;
+      salary: number;
+      job: number;
+    };
+  };
+  reasons: string[]; // 추천 이유들
+}


### PR DESCRIPTION
## 📌 개요
- GPT 기반 국가 추천 ->  API 3개 기반으로 변경

## 🗒️ 작업 내용 요약

- API 기반 국가 추천 기능 구현
- 입력 직무, 입력 언어 수정
- 이주 추천도 및 취업 가능성 계산 로직 삭제

## 🔗 관련 이슈
- Closes #54 