### PR TITLE
[feat] 사용자 이력 입력 단계 우선순위 로직 삭제 -> 언어, 연봉, 직무 가중치(합 100) 입력 받는 로직 추가 (#56)

### DIFF
--- a/src/constants/dropdownOptions.ts
+++ b/src/constants/dropdownOptions.ts
@@ -99,13 +99,6 @@ export const PRIORITY_OPTIONS = {
   },
 } as const;
 
-// 우선순위 가중치
-export const PRIORITY_WEIGHTS = {
-  first: 0.5,  // 1순위 가중치
-  second: 0.3, // 2순위 가중치  
-  third: 0.2,  // 3순위 가중치
-} as const;
-
 // 타입 정의
 export type SupportedLanguage = typeof SUPPORTED_LANGUAGES[number];
 export type JobFieldCode = typeof JOB_FIELDS[number]["code"];

--- a/src/controllers/countryRecommendationController.ts
+++ b/src/controllers/countryRecommendationController.ts
@@ -3,322 +3,80 @@ import {
   UserCareerProfile,
   CountryRecommendation,
 } from "../types/countryRecommendation";
-import { CountryRecommendationService } from "../services/countryRecommendationService";
+import { CountryRecommendationService, saveWeights } from "../services/countryRecommendationService";
 import { asyncHandler } from "../utils/asyncHandler";
 import CountryRecommendationResult from "../models/countryRecommendationResult";
 import UserProfile from "../models/UserProfile";
 import { AuthRequest } from "../middlewares/authMiddleware";
 import { SUPPORTED_LANGUAGES, JOB_FIELDS } from "../constants/dropdownOptions";
 
-// 인증된 사용자의 특정 프로필 기반 국가 추천 (중복 체크 및 저장)
-export const getCountryRecommendations = asyncHandler(
-  async (req: Request, res: Response) => {
-    const authReq = req as AuthRequest;
-    const userProfile: UserCareerProfile = req.body;
-    const { profileId } = req.params; // URL 파라미터에서 profileId 가져오기
+// 연봉 문자열을 숫자로 변환하는 함수
+function convertSalaryToNumber(salaryString: string): number {
+  const salaryMap: { [key: string]: number } = {
+    "2천만 이하": 20000,
+    "2천만 ~ 3천만": 25000,
+    "3천만 ~ 5천만": 40000,
+    "5천만 ~ 7천만": 60000,
+    "7천만 ~ 1억": 85000,
+    "1억 이상": 120000,
+    "기타 (직접 입력)": 50000, // 기본값
+  };
+  return salaryMap[salaryString] || 50000;
+}
 
-    // 인증된 사용자 확인
-    if (!authReq.user) {
-      return res.status(401).json({
-        success: false,
-        message: "인증이 필요합니다.",
-      });
-    }
+// 언어 문자열을 표준화하는 함수  
+function normalizeLanguage(language: string): string {
+  const languageMap: { [key: string]: string } = {
+    "English": "english",
+    "Japanese": "japanese", 
+    "Chinese": "chinese",
+    "German": "german",
+    "French": "french",
+    "Spanish": "spanish",
+    "Korean": "korean",
+    "Other": "english", // 기본값으로 영어
+  };
+  return languageMap[language] || "english";
+}
 
-    // profileId 필수 확인
-    if (!profileId) {
-      return res.status(400).json({
-        success: false,
-        message: "프로필 ID가 필요합니다.",
-      });
-    }
+// 직무명으로부터 ISCO 코드를 가져오는 함수
+function getISCOCode(jobNameKo: string): string {
+  const jobMapping: { [key: string]: string } = {
+    "IT / 개발": "2",
+    "디자인": "2", 
+    "의료 / 보건": "2",
+    "교육": "2",
+    "요리 / 식음료": "5",
+    "건축 / 기술직": "7",
+    "미용 / 서비스": "5",
+    "경영 / 사무 / 마케팅": "1",
+    "자영업 / 창업": "1",
+    "기타 (직접 입력)": "2",
+  };
+  return jobMapping[jobNameKo] || "2";
+}
 
-    // 입력 데이터 검증
-    const validationError = validateUserProfile(userProfile);
-    if (validationError) {
-      return res.status(400).json({
-        success: false,
-        message: validationError,
-      });
-    }
-
-    // 인증된 사용자이고 profileId가 있는 경우 중복 체크 및 저장 처리
-    if (authReq.user && profileId) {
-      // 해당 프로필 조회
-      const dbProfile = await UserProfile.findOne({
-        _id: profileId,
-        user: authReq.user._id,
-      });
-
-      if (!dbProfile) {
-        return res.status(404).json({
-          success: false,
-          message: "프로필을 찾을 수 없습니다.",
-        });
-      }
-
-      // 이미 해당 프로필에 대한 추천 결과가 있는지 확인
-      const existingRecommendation = await CountryRecommendationResult.findOne({
-        user: authReq.user._id,
-        profile: profileId,
-      }).sort({ createdAt: -1 });
-
-      if (existingRecommendation) {
-        return res.status(200).json({
-          success: true,
-          message: "이미 추천받은 이력입니다.",
-          data: {
-            isExisting: true,
-            recommendationId: existingRecommendation._id,
-            profileId: profileId,
-            createdAt: existingRecommendation.createdAt,
-          },
-        });
-      }
-    }
-
-    console.log("국가 추천 요청:", {
-      language: userProfile.language,
-      expectedSalary: userProfile.expectedSalary,
-      jobField: userProfile.jobField,
-      priorities: userProfile.priorities,
-    });
-
-    try {
-      // 국가 추천 서비스 호출
-      const recommendations: CountryRecommendation[] =
-        await CountryRecommendationService.getTopCountryRecommendations(
-          userProfile
-        );
-
-      // 인증된 사용자이고 profileId가 있는 경우 결과 저장
-      let savedRecommendationId = null;
-      if (authReq.user && profileId) {
-        const savedResult = new CountryRecommendationResult({
-          user: authReq.user._id,
-          profile: profileId,
-          recommendations: recommendations.map((rec, index) => ({
-            country: rec.country.name,
-            score: rec.totalScore,
-            rank: index + 1,
-            details: {
-              economicScore: rec.breakdown.languageScore,
-              employmentScore: rec.breakdown.jobScore,
-              languageScore: rec.breakdown.languageScore,
-              salaryScore: rec.breakdown.salaryScore,
-            },
-            economicData: {
-              gdpPerCapita: rec.country.gdpPerCapita || 0,
-              employmentRate: rec.country.employmentRate || 0,
-              averageSalary: 0,
-            },
-            countryInfo: {
-              region: rec.country.region,
-              languages: rec.country.languages,
-              population: rec.country.population || 0,
-            },
-          })),
-        });
-
-        await savedResult.save();
-        savedRecommendationId = savedResult._id;
-      }
-
-      res.status(200).json({
-        success: true,
-        message:
-          authReq.user && profileId
-            ? "국가 추천이 완료되고 저장되었습니다."
-            : "국가 추천이 완료되었습니다.",
-        data: {
-          isExisting: false,
-          recommendationId: savedRecommendationId,
-          profileId: profileId || null,
-          userProfile: {
-            language: userProfile.language,
-            expectedSalary: userProfile.expectedSalary,
-            jobField: userProfile.jobField,
-            priorities: userProfile.priorities,
-          },
-          recommendations,
-          appliedWeights: {
-            first: 0.5,
-            second: 0.3,
-            third: 0.2,
-          },
-          timestamp: new Date().toISOString(),
-        },
-      });
-    } catch (error) {
-      console.error("국가 추천 처리 오류:", error);
-
-      res.status(500).json({
-        success: false,
-        message: "국가 추천 처리 중 서버 오류가 발생했습니다.",
-        error: process.env.NODE_ENV === "development" ? error : undefined,
-      });
-    }
-  }
-);
-
-// 인증된 사용자용 국가 추천 (결과 저장)
-export const getCountryRecommendationsForUser = asyncHandler(
-  async (req: AuthRequest, res: Response) => {
-    const { profileId } = req.body;
-
-    if (!req.user) {
-      return res.status(401).json({
-        success: false,
-        message: "인증이 필요합니다.",
-      });
-    }
-
-    // profileId가 필수로 제공되어야 함
-    if (!profileId) {
-      return res.status(400).json({
-        success: false,
-        message: "profileId가 필요합니다.",
-      });
-    }
-
-    // 해당 프로필 조회
-    const userProfile = await UserProfile.findOne({
-      _id: profileId,
-      user: req.user._id,
-    });
-
-    if (!userProfile) {
-      return res.status(404).json({
-        success: false,
-        message: "프로필을 찾을 수 없습니다.",
-      });
-    }
-
-    // 이미 해당 프로필에 대한 추천 결과가 있는지 확인
-    const existingRecommendation = await CountryRecommendationResult.findOne({
-      user: req.user._id,
-      profile: profileId,
-    }).sort({ createdAt: -1 });
-
-    if (existingRecommendation) {
-      return res.status(200).json({
-        success: true,
-        message: "이미 추천받은 이력입니다.",
-        data: {
-          isExisting: true,
-          recommendationId: existingRecommendation._id,
-          profileId: profileId,
-          createdAt: existingRecommendation.createdAt,
-        },
-      });
-    }
-
-    // UserProfile을 UserCareerProfile로 변환
-    const careerProfile: UserCareerProfile = {
-      language: userProfile.language,
-      expectedSalary: userProfile.desiredSalary
-        ? parseInt(userProfile.desiredSalary.replace(/[^0-9]/g, ""))
-        : 50000,
-      jobField: userProfile.desiredJob
-        ? {
-            code: "2", // 기본값으로 "전문가" 설정
-            nameKo: userProfile.desiredJob.mainCategory || "기타",
-            nameEn: "Professionals",
-          }
-        : {
-            code: "2",
-            nameKo: "기타",
-            nameEn: "Other",
-          },
-      priorities: req.body.priorities || {
-        first: "language",
-        second: "salary",
-        third: "job",
-      },
-    };
-
-    // 입력 데이터 검증
-    const validationError = validateUserProfile(careerProfile);
-    if (validationError) {
-      return res.status(400).json({
-        success: false,
-        message: validationError,
-      });
-    }
-
-    try {
-      // 국가 추천 서비스 호출
-      const recommendations: CountryRecommendation[] =
-        await CountryRecommendationService.getTopCountryRecommendations(
-          careerProfile
-        );
-
-      // 추천 결과 저장
-      const savedResult = new CountryRecommendationResult({
-        user: req.user._id,
-        profile: userProfile._id,
-        recommendations: recommendations.map((rec, index) => ({
-          country: rec.country.name,
-          score: rec.totalScore,
-          rank: index + 1,
-          details: {
-            economicScore: rec.breakdown.languageScore,
-            employmentScore: rec.breakdown.jobScore,
-            languageScore: rec.breakdown.languageScore,
-            salaryScore: rec.breakdown.salaryScore,
-          },
-          economicData: {
-            gdpPerCapita: rec.country.gdpPerCapita || 0,
-            employmentRate: rec.country.employmentRate || 0,
-            averageSalary: 0, // 현재 타입에 없음
-          },
-          countryInfo: {
-            region: rec.country.region,
-            languages: rec.country.languages,
-            population: rec.country.population || 0,
-          },
-        })),
-      });
-
-      await savedResult.save();
-
-      res.status(200).json({
-        success: true,
-        message: "국가 추천이 완료되고 저장되었습니다.",
-        data: {
-          isExisting: false,
-          recommendationId: savedResult._id,
-          profileId: profileId,
-          userProfile: {
-            language: careerProfile.language,
-            expectedSalary: careerProfile.expectedSalary,
-            jobField: careerProfile.jobField,
-            priorities: careerProfile.priorities,
-          },
-          recommendations,
-          appliedWeights: {
-            first: 0.5,
-            second: 0.3,
-            third: 0.2,
-          },
-          timestamp: new Date().toISOString(),
-        },
-      });
-    } catch (error) {
-      console.error("국가 추천 처리 오류:", error);
-
-      res.status(500).json({
-        success: false,
-        message: "국가 추천 처리 중 서버 오류가 발생했습니다.",
-        error: process.env.NODE_ENV === "development" ? error : undefined,
-      });
-    }
-  }
-);
+// 직무명으로부터 영어 직무명을 가져오는 함수
+function getEnglishJobName(jobNameKo: string): string {
+  const jobMapping: { [key: string]: string } = {
+    "IT / 개발": "IT Professionals",
+    "디자인": "Design Professionals", 
+    "의료 / 보건": "Health Professionals",
+    "교육": "Education Professionals",
+    "요리 / 식음료": "Food Service Workers",
+    "건축 / 기술직": "Craft and Skilled Workers",
+    "미용 / 서비스": "Service Workers",
+    "경영 / 사무 / 마케팅": "Managers",
+    "자영업 / 창업": "Business Owners",
+    "기타 (직접 입력)": "Professionals",
+  };
+  return jobMapping[jobNameKo] || "Professionals";
+}
 
 // 사용자 프로필 검증 함수
 function validateUserProfile(profile: UserCareerProfile): string | null {
   // 필수 필드 검증
+  console.log("이력", profile)
   if (!profile.language || profile.language.trim() === "") {
     return "사용 가능한 언어를 선택해주세요.";
   }
@@ -337,28 +95,6 @@ function validateUserProfile(profile: UserCareerProfile): string | null {
     return "ISCO-08 표준 직무 분류 코드를 선택해주세요.";
   }
 
-  if (!profile.priorities) {
-    return "우선순위를 설정해주세요.";
-  }
-
-  // 우선순위 검증
-  const { first, second, third } = profile.priorities;
-  const validPriorities = ["language", "salary", "job"];
-
-  if (
-    !validPriorities.includes(first) ||
-    !validPriorities.includes(second) ||
-    !validPriorities.includes(third)
-  ) {
-    return "우선순위는 language, salary, job 중에서 선택해주세요.";
-  }
-
-  // 우선순위 중복 검증
-  const prioritySet = new Set([first, second, third]);
-  if (prioritySet.size !== 3) {
-    return "우선순위는 서로 다른 값이어야 합니다.";
-  }
-
   // 연봉 범위 검증
   if (profile.expectedSalary < 10000 || profile.expectedSalary > 500000) {
     return "희망 연봉은 $10,000 ~ $500,000 범위로 입력해주세요.";
@@ -371,3 +107,222 @@ function validateUserProfile(profile: UserCareerProfile): string | null {
 
   return null; // 검증 통과
 }
+
+// 가중치 설정 핸들러
+export const setWeights = asyncHandler(async (req: Request, res: Response) => {
+  const { language, salary, job } = req.body;
+
+  if (
+    [language, salary, job].some((weight) => weight % 10 !== 0) ||
+    language + salary + job !== 100
+  ) {
+    return res.status(400).json({
+      success: false,
+      message: "가중치는 10단위여야 하며, 합이 100이어야 합니다.",
+    });
+  }
+
+  // 가중치 저장
+  saveWeights({ language, salary, job });
+
+  res.status(200).json({
+    success: true,
+    message: "가중치가 성공적으로 저장되었습니다.",
+  });
+});
+
+// 사용자 인증 및 프로필 ID 검증 함수
+async function validateUserAndProfile(req: AuthRequest, profileId: string) {
+  if (!req.user) {
+    throw { status: 401, message: "인증이 필요합니다." };
+  }
+
+  if (!profileId) {
+    throw { status: 400, message: "프로필 ID가 필요합니다." };
+  }
+
+  const dbProfile = await UserProfile.findOne({
+    _id: profileId,
+    user: req.user._id,
+  });
+
+  if (!dbProfile) {
+    throw { status: 404, message: "프로필을 찾을 수 없습니다." };
+  }
+
+  return dbProfile;
+}
+
+// 추천 결과 저장 함수
+async function saveRecommendation(
+  userId: string, 
+  profileId: string, 
+  recommendations: CountryRecommendation[], 
+  weights: { language: number; salary: number; job: number }
+) {
+  const savedResult = new CountryRecommendationResult({
+    user: userId,
+    profile: profileId,
+    weights,
+    recommendations: recommendations.map((rec, index) => ({
+      country: rec.country.name,
+      score: rec.totalScore,
+      rank: index + 1,
+      details: {
+        economicScore: rec.breakdown.languageScore,
+        employmentScore: rec.breakdown.jobScore,
+        languageScore: rec.breakdown.languageScore,
+        salaryScore: rec.breakdown.salaryScore,
+      },
+      economicData: {
+        gdpPerCapita: rec.country.gdpPerCapita || 0,
+        employmentRate: rec.country.employmentRate || 0,
+        averageSalary: 0,
+      },
+      countryInfo: {
+        region: rec.country.region,
+        languages: rec.country.languages,
+        population: rec.country.population || 0,
+      },
+    })),
+  });
+
+  await savedResult.save();
+  return savedResult._id;
+}
+
+// 국가 추천 핸들러
+export const getCountryRecommendations = asyncHandler(
+  async (req: Request, res: Response) => {
+    const authReq = req as AuthRequest;
+    
+    // URL 파라미터에서 프로필 ID 가져오기
+    const profileId = req.params.profileId;
+
+    console.log("===== 국가 추천 요청 시작 =====");
+    console.log("프로필 ID:", profileId);
+    console.log("사용자 ID:", authReq.user?._id);
+
+    try {
+      // 프로필 ID 검증 -> 회원용
+      if (!profileId) {
+        return res.status(400).json({
+          success: false,
+          message: "프로필 ID가 필요합니다. 게스트 사용자는 /api/guest/recommend를 사용하세요.",
+        });
+      }
+
+      // 데이터베이스에서 프로필 가져오기
+      const dbProfile = await validateUserAndProfile(authReq, profileId);
+
+      // 가중치 검증 (반드시 있어야 함)
+      if (!dbProfile.weights || 
+          dbProfile.weights.languageWeight === undefined || 
+          dbProfile.weights.salaryWeight === undefined || 
+          dbProfile.weights.jobWeight === undefined) {
+        return res.status(400).json({
+          success: false,
+          message: "프로필에 가중치 정보가 없습니다. 프로필을 다시 등록해주세요.",
+          data: {
+            profileId: profileId,
+            currentWeights: dbProfile.weights
+          }
+        });
+      }
+
+      const weights = {
+        language: dbProfile.weights.languageWeight,
+        salary: dbProfile.weights.salaryWeight,
+        job: dbProfile.weights.jobWeight,
+      };
+
+      // 데이터베이스 프로필을 UserCareerProfile 형식으로 변환
+      const mainCategory = dbProfile.desiredJob?.mainCategory || "기타 (직접 입력)";
+      
+      const userProfile = {
+        language: normalizeLanguage(dbProfile.language || "English"),
+        expectedSalary: dbProfile.desiredSalary ? 
+          convertSalaryToNumber(dbProfile.desiredSalary) : 50000,
+        jobField: {
+          code: getISCOCode(mainCategory),
+          nameKo: mainCategory,
+          nameEn: getEnglishJobName(mainCategory),
+        },
+      };
+
+      console.log("추천 요청 프로필:", userProfile);
+      console.log("적용된 가중치:", weights);
+
+      // 가중치를 서비스에서 사용할 수 있도록 저장
+      saveWeights(weights);
+
+      const recommendations = await CountryRecommendationService.getTopCountryRecommendations(userProfile);
+
+      // 프로필 ID가 있는 경우에만 저장, 없으면 빈 문자열로 처리
+      const finalProfileId = profileId || "";
+
+      const savedRecommendationId = await saveRecommendation(
+        authReq.user!._id.toString(), 
+        finalProfileId, 
+        recommendations, 
+        weights
+      );
+
+      res.status(200).json({
+        success: true,
+        message: "국가 추천이 완료되고 저장되었습니다.",
+        data: {
+          isExisting: false,
+          recommendationId: savedRecommendationId,
+          profileId: profileId || null,
+          userProfile,
+          recommendations,
+          appliedWeights: {
+            language: weights.language / 100,
+            salary: weights.salary / 100,
+            job: weights.job / 100,
+          },
+          timestamp: new Date().toISOString(),
+        },
+      });
+    } catch (error) {
+      if ((error as any).status) {
+        return res.status((error as any).status).json({ 
+          success: false, 
+          message: (error as any).message 
+        });
+      }
+      console.error("국가 추천 처리 오류:", error);
+      res.status(500).json({ 
+        success: false, 
+        message: "국가 추천 처리 중 서버 오류가 발생했습니다.",
+        error: process.env.NODE_ENV === 'development' ? (error as any).message : undefined
+      });
+    }
+  }
+);
+
+// 사용자 프로필 등록 핸들러
+export const registerUserProfile = asyncHandler(async (req: Request, res: Response) => {
+  const userProfile: UserCareerProfile = {
+    language: req.body.language,
+    expectedSalary: req.body.expectedSalary,
+    jobField: req.body.jobField,
+    weights: {
+      languageWeight: req.body.languageWeight,
+      salaryWeight: req.body.salaryWeight,
+      jobWeight: req.body.jobWeight,
+    },
+  };
+
+  // 가중치 검증
+  if ([req.body.languageWeight, req.body.salaryWeight, req.body.jobWeight].some((weight) => weight % 10 !== 0) || 
+      req.body.languageWeight + req.body.salaryWeight + req.body.jobWeight !== 100) {
+    return res.status(400).json({
+      success: false,
+      message: "가중치는 10단위여야 하며, 합이 100이어야 합니다.",
+    });
+  }
+
+  // 사용자 프로필 저장 로직
+});

--- a/src/controllers/profileController.ts
+++ b/src/controllers/profileController.ts
@@ -5,7 +5,33 @@ import { Types } from "mongoose";
 
 // 사용자 이력 등록 (POST /api/profile)
 export const createProfile = async (req: AuthRequest, res: Response) => {
-  const { language, desiredSalary, desiredJob, additionalNotes } = req.body;
+  const { 
+    language, 
+    desiredSalary, 
+    desiredJob, 
+    additionalNotes,
+    weights // 가중치 추가
+  } = req.body;
+
+  // 가중치 기본값 설정 및 검증
+  const finalWeights = {
+    languageWeight: weights?.languageWeight || 30,
+    salaryWeight: weights?.salaryWeight || 30,
+    jobWeight: weights?.jobWeight || 40,
+  };
+
+  // 가중치 검증
+  const totalWeight = finalWeights.languageWeight + finalWeights.salaryWeight + finalWeights.jobWeight;
+  if (totalWeight !== 100) {
+    return res.status(400).json({
+      code: 400,
+      message: "가중치의 합이 100이어야 합니다.",
+      data: { 
+        currentTotal: totalWeight,
+        weights: finalWeights
+      },
+    });
+  }
 
   // 이전 이력과 동일한 내용이면 등록 불가
   const normalize = (value: string) => (value || "").trim().toLowerCase();
@@ -25,7 +51,11 @@ export const createProfile = async (req: AuthRequest, res: Response) => {
       profile.desiredSalary === desiredSalary &&
       compareJobCategory(profile.desiredJob, desiredJob) &&
       normalize(profile.additionalNotes || "") ===
-        normalize(additionalNotes || "")
+        normalize(additionalNotes || "") &&
+      // 가중치 비교
+      profile.weights?.languageWeight === finalWeights.languageWeight &&
+      profile.weights?.salaryWeight === finalWeights.salaryWeight &&
+      profile.weights?.jobWeight === finalWeights.jobWeight
     );
   });
 
@@ -44,12 +74,15 @@ export const createProfile = async (req: AuthRequest, res: Response) => {
     language,
     desiredSalary,
     desiredJob,
+    weights: finalWeights, // 가중치 저장
     additionalNotes,
   });
 
   res.status(201).json({
     code: 201,
-    message: "이력이 정상적으로 등록되었습니다.",
-    data: null,
+    message: "이력과 가중치가 정상적으로 등록되었습니다.",
+    data: {
+      profileId: profile._id,
+    },
   });
 };

--- a/src/docs/countryRecommendationDocs.ts
+++ b/src/docs/countryRecommendationDocs.ts
@@ -52,33 +52,29 @@ export const countryRecommendationSwaggerDocs = {
                     },
                     required: ["code", "nameKo", "nameEn"],
                   },
-                  priorities: {
-                    type: "object",
-                    properties: {
-                      first: {
-                        type: "string",
-                        enum: ["language", "salary", "job"],
-                        example: "language",
-                      },
-                      second: {
-                        type: "string",
-                        enum: ["language", "salary", "job"],
-                        example: "salary",
-                      },
-                      third: {
-                        type: "string",
-                        enum: ["language", "salary", "job"],
-                        example: "job",
-                      },
-                    },
-                    required: ["first", "second", "third"],
+                  languageWeight: {
+                    type: "integer",
+                    description: "언어 가중치 (10 단위)",
+                    example: 50,
+                  },
+                  salaryWeight: {
+                    type: "integer",
+                    description: "연봉 가중치 (10 단위)",
+                    example: 30,
+                  },
+                  jobWeight: {
+                    type: "integer",
+                    description: "직무 가중치 (10 단위)",
+                    example: 20,
                   },
                 },
                 required: [
                   "language",
                   "expectedSalary",
                   "jobField",
-                  "priorities",
+                  "languageWeight",
+                  "salaryWeight",
+                  "jobWeight",
                 ],
               },
             },

--- a/src/docs/profileDocs.ts
+++ b/src/docs/profileDocs.ts
@@ -5,7 +5,7 @@ export const profileSwaggerDocs = {
       post: {
         summary: "사용자 이력 등록",
         description:
-          "사용자의 언어 능력, 희망 연봉, 직무, 추가 메모 등을 등록합니다. 동일한 내용의 이력은 중복 등록이 불가합니다.",
+          "사용자의 언어 능력, 희망 연봉, 직무, 가중치, 추가 메모 등을 등록합니다. 동일한 내용의 이력은 중복 등록이 불가합니다.",
         tags: ["Profile"],
         security: [{ bearerAuth: [] }],
         requestBody: {
@@ -53,12 +53,34 @@ export const profileSwaggerDocs = {
                       },
                     },
                   },
+                  languageWeight: {
+                    type: "integer",
+                    description: "언어 가중치 (10 단위)",
+                    example: 40,
+                  },
+                  salaryWeight: {
+                    type: "integer",
+                    description: "연봉 가중치 (10 단위)",
+                    example: 30,
+                  },
+                  jobWeight: {
+                    type: "integer",
+                    description: "직무 가중치 (10 단위)",
+                    example: 30,
+                  },
                   additionalNotes: {
                     type: "string",
                     example: "원격 근무 원함",
                   },
                 },
-                required: ["language", "desiredSalary", "desiredJob"],
+                required: [
+                  "language",
+                  "desiredSalary",
+                  "desiredJob",
+                  "languageWeight",
+                  "salaryWeight",
+                  "jobWeight",
+                ],
               },
             },
           },

--- a/src/models/UserProfile.ts
+++ b/src/models/UserProfile.ts
@@ -117,6 +117,31 @@ const userProfileSchema = new mongoose.Schema({
     },
   },
 
+  // 가중치 설정 (합계 100%)
+  weights: {
+    languageWeight: {
+      type: Number,
+      required: true,
+      min: 0,
+      max: 100,
+      default: 30
+    },
+    salaryWeight: {
+      type: Number,
+      required: true,
+      min: 0,
+      max: 100,
+      default: 30
+    },
+    jobWeight: {
+      type: Number,
+      required: true,
+      min: 0,
+      max: 100,
+      default: 40
+    }
+  },
+
   additionalNotes: { type: String }, // 추가 희망 사항
   createdAt: { type: Date, default: Date.now },
 });

--- a/src/models/countryRecommendationResult.ts
+++ b/src/models/countryRecommendationResult.ts
@@ -31,6 +31,11 @@ const CountryRecommendationResultSchema = new mongoose.Schema(
         },
       },
     ],
+    weights: {
+      language: { type: Number, required: true },
+      salary: { type: Number, required: true },
+      job: { type: Number, required: true },
+    },
   },
   { timestamps: true }
 );
@@ -39,3 +44,10 @@ export default mongoose.model(
   "CountryRecommendationResult",
   CountryRecommendationResultSchema
 );
+export interface CountryRecommendationResult {
+  weights: {
+    language: number;
+    salary: number;
+    job: number;
+  };
+}

--- a/src/routes/countryRecommendationRoutes.ts
+++ b/src/routes/countryRecommendationRoutes.ts
@@ -5,9 +5,9 @@ import { protect } from "../middlewares/authMiddleware";
 const router = Router();
 
 /**
- * POST /api/country-recommendations/:profileId
- * 인증된 사용자의 특정 프로필 기반 국가 추천 (중복 체크 및 저장)
+ * GET /api/country-recommendations/:profileId
+ * 인증된 사용자의 특정 프로필 기반 국가 추천
  */
-router.post("/:profileId", protect, getCountryRecommendations);
+router.get("/:profileId", protect, getCountryRecommendations);
 
 export default router;

--- a/src/routes/guestRoutes.ts
+++ b/src/routes/guestRoutes.ts
@@ -1,17 +1,11 @@
 import express from "express";
 import {
   getGuestCountryRecommendations,
-  deprecatedNotice,
 } from "../controllers/guestController";
 
 const router = express.Router();
 
 // 비회원 국가 추천 엔드포인트
 router.post("/recommend", getGuestCountryRecommendations);
-
-// 기존 GPT 기반 엔드포인트들 - 더 이상 사용되지 않음
-router.post("/profile", deprecatedNotice);
-router.post("/migrate", deprecatedNotice);
-router.get("/migrate/:id", deprecatedNotice);
 
 export default router;

--- a/src/types/countryRecommendation.ts
+++ b/src/types/countryRecommendation.ts
@@ -3,7 +3,14 @@ export interface UserCareerProfile {
   language: string; // 사용 가능 언어 (단일 선택)
   expectedSalary: number; // 희망 연봉 (USD)
   jobField: ISCOJobField; // ISCO-08 기준 직무 분야
-  priorities: UserPriorities; // 우선순위
+  languageScore?: number; // 언어 점수
+  salaryScore?: number; // 연봉 점수
+  jobScore?: number; // 직무 점수
+  weights?: {
+    languageWeight: number; // 언어 가중치
+    salaryWeight: number; // 연봉 가중치
+    jobWeight: number; // 직무 가중치
+  };
 }
 
 // ISCO-08 직무 분류
@@ -13,11 +20,6 @@ export interface ISCOJobField {
   nameEn: string; // 영어 직무명
 }
 
-export interface UserPriorities {
-  first: "language" | "salary" | "job"; // 1순위 (가중치 0.5)
-  second: "language" | "salary" | "job"; // 2순위 (가중치 0.3)
-  third: "language" | "salary" | "job"; // 3순위 (가중치 0.2)
-}
 
 // 국가 데이터 타입
 export interface CountryData {

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -12,7 +12,7 @@
 
     /* Interop Constraints */
     "typeRoots": ["./src/types", "./node_modules/@types"],
-    "types": ["node", "express"], // ✅ 추가: Express 타입 강제 로드
+    "types": ["node", "express"], 
     "esModuleInterop": true,
     "forceConsistentCasingInFileNames": true,
     "moduleResolution": "node",
@@ -23,6 +23,6 @@
     /* Completeness */
     "skipLibCheck": true
   },
-  "include": ["src/**/*", "types/**/*.d.ts"], // ✅ types 폴더 포함
+  "include": ["src/**/*", "types/**/*.d.ts"], 
   "exclude": ["node_modules"]
 }


### PR DESCRIPTION
## 📌 개요
- 사용자 이력 입력 단계 우선순위 로직 삭제 -> 언어, 연봉, 직무 가중치(합 100) 입력 받는 로직 추가

## 🗒️ 작업 내용 요약
- 국가 추천 HTTP 메서드 POST → GET
- 우선순위 기능 삭제, 가중치 기능 구현 
- controllers/countryRecommendationController 중복 로직 삭제 

## 🔗 관련 이슈
- Closes #56 
