### PR TITLE
feat: Quality of Life 점수 계산 로직 수정 (Box-cox 변환 적용)

### DIFF
--- a/src/constants/dropdownOptions.ts
+++ b/src/constants/dropdownOptions.ts
@@ -1,22 +1,32 @@
 // 클라이언트에서 사용할 드롭다운 옵션 데이터
 
-// 지원 가능한 언어 목록
+// 지원 가능한 언어 목록 (OECD 40개국 공식 언어 전체 포함)
 export const SUPPORTED_LANGUAGES = [
   "Korean",
   "English",
-  "Chinese",
-  "Japanese",
   "Spanish",
   "French",
   "German",
-  "Italian",
   "Portuguese",
-  "Russian",
-  "Arabic",
-  "Hindi",
+  "Italian",
   "Dutch",
   "Swedish",
   "Norwegian",
+  "Danish",
+  "Finnish",
+  "Polish",
+  "Czech",
+  "Hungarian",
+  "Greek",
+  "Turkish",
+  "Japanese",
+  "Hebrew",
+  "Slovak",
+  "Slovene",
+  "Icelandic",
+  "Estonian",
+  "Latvian",
+  "Lithuanian",
 ] as const;
 
 // 직무 분야 목록 (ILOSTAT ISCO-08 대분류 기준)
@@ -87,27 +97,27 @@ export const JOB_FIELDS = [
 export const QUALITY_OF_LIFE_INDICATORS = {
   income: {
     label: "소득 (Income)",
-    description: "가구 순자산, 가구 순조정 가처분소득",
+    description: "가구 순자산, 가구 순조정 가처분소득, 소득 분배 관련 지표",
     unit: "USD",
   },
   jobs: {
     label: "일자리 (Jobs)",
-    description: "고용률, 장기실업률, 개인소득",
+    description: "고용률, 장기실업률, 평균 연간 임금, 직업 안전성",
     unit: "%",
   },
   health: {
     label: "건강 (Health)",
-    description: "기대수명, 건강상태 자가평가",
+    description: "기대수명, 건강상태 자가평가, 예방 가능 및 치료 가능 사망률",
     unit: "years/score",
   },
   lifeSatisfaction: {
     label: "삶의 만족도 (Life Satisfaction)",
-    description: "삶의 만족도 평가 점수",
+    description: "삶의 만족도 평가 점수, 긍정적/부정적 경험 지표",
     unit: "0-10 scale",
   },
   safety: {
     label: "안전 (Safety)",
-    description: "야간 홀로 걷기 안전도, 강도 피해율",
+    description: "살인율, 야간 보행 안전 인식, 강도 피해율",
     unit: "%",
   },
 } as const;

--- a/src/controllers/profileController.ts
+++ b/src/controllers/profileController.ts
@@ -29,12 +29,13 @@ export const createProfile = async (req: AuthRequest, res: Response) => {
     });
   }
 
+  // 사용자가 입력한 가중치를 그대로 사용
   const finalQualityWeights = {
-    income: qualityOfLifeWeights.income || 20,
-    jobs: qualityOfLifeWeights.jobs || 20,
-    health: qualityOfLifeWeights.health || 20,
-    lifeSatisfaction: qualityOfLifeWeights.lifeSatisfaction || 20,
-    safety: qualityOfLifeWeights.safety || 20,
+    income: qualityOfLifeWeights.income ?? 0,
+    jobs: qualityOfLifeWeights.jobs ?? 0,
+    health: qualityOfLifeWeights.health ?? 0,
+    lifeSatisfaction: qualityOfLifeWeights.lifeSatisfaction ?? 0,
+    safety: qualityOfLifeWeights.safety ?? 0,
   };
 
   // 삶의 질 가중치 검증 (합계 100)

--- a/src/controllers/simulationController.ts
+++ b/src/controllers/simulationController.ts
@@ -481,7 +481,7 @@ export const getSimulationList = async (req: AuthRequest, res: Response) => {
   }
 };
 
-// 새로운 플로우: 국가 선택 후 GPT를 통한 도시 추천
+// 국가 선택 후 GPT를 통한 도시 추천
 export const selectCountryAndGetCities = async (
   req: AuthRequest,
   res: Response

--- a/src/docs/countryRecommendationDocs.ts
+++ b/src/docs/countryRecommendationDocs.ts
@@ -5,7 +5,7 @@ export const countryRecommendationSwaggerDocs = {
       get: {
         summary: "인증된 사용자의 특정 프로필 기반 국가 추천",
         description:
-          "특정 프로필 ID로 국가 추천을 요청합니다. 프로필에 저장된 정보(언어, 희망연봉, 직무, 가중치)를 사용하여 국가를 추천합니다.",
+          "특정 프로필 ID로 국가 추천을 요청합니다. 프로필에 저장된 정보(언어, QOL, 직무, 가중치)를 사용하여 국가를 추천합니다.",
         tags: ["Country Recommendations"],
         security: [{ bearerAuth: [] }],
         parameters: [

--- a/src/types/countryRecommendation.ts
+++ b/src/types/countryRecommendation.ts
@@ -33,7 +33,8 @@ export interface CountryData {
   region: string;
   languages: string[];
   gdpPerCapita?: number; // World Bank API에서 가져올 데이터
-  employmentRate?: number; // ILOSTAT API에서 가져올 데이터 (고용률)
+  employmentRate?: number; // ILOSTAT API에서 가져올 데이터 (전체 고용률)
+  iscoEmploymentData?: Map<string, number>; // ISCO-08 대분류별 고용 데이터
   population?: number;
 }
 


### PR DESCRIPTION
## 📄 작업 대상
 - Quality of Life 점수 계산 로직 수정 (Box-cox 변환 적용)
- 사용자 이력 입력 시 언어 드롭다운 항목 추가
- profileController.ts 의 finalQualityWeights 함수 0점도 고려하도록 수정

## ✅ 작업 내용
  - [x] Z-Score * 18 + 50 + Math.min(100)
- 평균 국가: 50점 (중간값 정규화), 최상위 국가: 최대 100점 (초과 방지), 최하위 국가: 최소 0점 (음수 방지) 0-100 범위 완벽 보장

## 💬 리뷰 요구사항

## 📎 기타 참고 사항
  - 관련 API 문서: http://localhost:5001/api-docs/
