### PR TITLE
[feat] 카카오 로그인 API 구현 (#68)

### DIFF
--- a/src/controllers/authController.ts
+++ b/src/controllers/authController.ts
@@ -1,7 +1,139 @@
 import { Request, Response } from "express";
 import bcrypt from "bcrypt";
+import axios from "axios";
 import User from "../models/User";
 import { generateToken } from "../utils/generateToken";
+
+// 카카오 로그인 - 인가 코드 요청 URL 생성
+export const getKakaoAuthUrl = (req: Request, res: Response) => {
+  const kakaoAuthUrl = `https://kauth.kakao.com/oauth/authorize?client_id=${process.env.KAKAO_REST_API_KEY}&redirect_uri=${process.env.KAKAO_REDIRECT_URI}&response_type=code`;
+
+  res.status(200).json({
+    code: 200,
+    message: "카카오 인증 URL 생성 성공",
+    data: { authUrl: kakaoAuthUrl },
+  });
+};
+
+// 카카오 로그인 - 콜백 처리
+export const kakaoCallback = async (req: Request, res: Response) => {
+  try {
+    const { code } = req.query;
+
+    if (!code) {
+      return res.status(400).json({
+        code: 400,
+        message: "인가 코드가 없습니다.",
+        data: null,
+      });
+    }
+
+    // 1. 액세스 토큰 받기
+    const tokenResponse = await axios.post(
+      "https://kauth.kakao.com/oauth/token",
+      null,
+      {
+        params: {
+          grant_type: "authorization_code",
+          client_id: process.env.KAKAO_REST_API_KEY,
+          redirect_uri: process.env.KAKAO_REDIRECT_URI,
+          code,
+        },
+        headers: {
+          "Content-Type": "application/x-www-form-urlencoded;charset=utf-8",
+        },
+      }
+    );
+
+    const { access_token } = tokenResponse.data;
+
+    // 2. 사용자 정보 가져오기
+    const userResponse = await axios.get("https://kapi.kakao.com/v2/user/me", {
+      headers: {
+        Authorization: `Bearer ${access_token}`,
+        "Content-Type": "application/x-www-form-urlencoded;charset=utf-8",
+      },
+    });
+
+    const kakaoUser = userResponse.data;
+    console.log("카카오 사용자 정보:", kakaoUser);
+    const kakaoId = kakaoUser.id.toString();
+    const email = kakaoUser.kakao_account?.email;
+    const name = kakaoUser.kakao_account?.profile?.nickname || "카카오사용자";
+    const phone = kakaoUser.kakao_account?.phone_number;
+    const birthday = kakaoUser.kakao_account?.birthday; // MMDD 형식
+    const birthyear = kakaoUser.kakao_account?.birthyear; // YYYY 형식
+
+    if (!email) {
+      return res.status(400).json({
+        code: 400,
+        message: "카카오 계정에서 이메일을 가져올 수 없습니다.",
+        data: null,
+      });
+    }
+
+    // 3. 사용자 확인 또는 생성
+    let user = await User.findOne({ kakaoId });
+
+    if (!user) {
+      // 이메일로 기존 사용자 확인
+      const existingUser = await User.findOne({ email });
+
+      if (existingUser) {
+        // 기존 일반 회원가입 사용자가 있는 경우
+        if (existingUser.provider === "local" && !existingUser.kakaoId) {
+          // 일반 회원가입 계정이 이미 존재 - 보안상 연동 차단
+          return res.status(409).json({
+            code: 409,
+            message:
+              "이미 해당 이메일로 가입된 계정이 있습니다. 일반 로그인을 이용해주세요.",
+            data: null,
+          });
+        }
+        // 이미 카카오 정보가 있는 경우 (정상 케이스)
+        user = existingUser;
+      } else {
+        // 새로운 사용자 생성
+        const birth =
+          birthyear && birthday
+            ? `${birthyear}-${birthday.slice(0, 2)}-${birthday.slice(2, 4)}`
+            : undefined;
+
+        user = new User({
+          name,
+          email,
+          kakaoId,
+          provider: "kakao",
+          phone,
+          birth,
+        });
+        await user.save();
+      }
+    }
+
+    // 4. JWT 토큰 생성
+    const token = generateToken(user._id.toString());
+
+    res.status(200).json({
+      code: 200,
+      message: "카카오 로그인 성공!",
+      data: {
+        name: user.name,
+        email: user.email,
+        birth: user.birth,
+        phone: user.phone,
+        token,
+      },
+    });
+  } catch (error) {
+    console.error("카카오 로그인 오류:", error);
+    res.status(500).json({
+      code: 500,
+      message: "카카오 로그인 처리 중 오류가 발생했습니다.",
+      data: null,
+    });
+  }
+};
 
 // 회원가입
 export const register = async (req: Request, res: Response) => {
@@ -55,6 +187,15 @@ export const login = async (req: Request, res: Response) => {
     });
   }
 
+  // 카카오 로그인 사용자 체크
+  if (!user.password) {
+    return res.status(401).json({
+      code: 401,
+      message: "카카오 로그인 사용자입니다. 카카오 로그인을 이용해주세요.",
+      data: null,
+    });
+  }
+
   const isMatch = await bcrypt.compare(password, user.password);
   if (!isMatch) {
     return res.status(401).json({
@@ -71,6 +212,8 @@ export const login = async (req: Request, res: Response) => {
     data: {
       name: user.name,
       email: user.email,
+      birth: user.birth,
+      phone: user.phone,
       token,
     },
   });

--- a/src/controllers/guestController.ts
+++ b/src/controllers/guestController.ts
@@ -3,19 +3,12 @@ import {
   UserCareerProfile,
   CountryRecommendation,
 } from "../types/countryRecommendation";
-import { CountryRecommendationService } from "../services/countryRecommendationService";
+import {
+  CountryRecommendationService,
+  saveWeights,
+} from "../services/countryRecommendationService";
 import { asyncHandler } from "../utils/asyncHandler";
-
-// saveWeights 함수 import (가중치 사용할 수 있도록)
-let savedWeights = { language: 30, job: 30, qualityOfLife: 40 };
-export const saveWeights = (weights: {
-  language: number;
-  job: number;
-  qualityOfLife: number;
-}) => {
-  savedWeights = weights;
-};
-export const getSavedWeights = () => savedWeights;
+import { SUPPORTED_LANGUAGES, JOB_FIELDS } from "../constants/dropdownOptions";
 
 // 비회원 국가 추천 요청 처리 (회원과 동일한 로직, DB 저장 없음)
 export const getGuestCountryRecommendations = asyncHandler(
@@ -129,7 +122,7 @@ function validateGuestProfile(profile: UserCareerProfile): string | null {
   }
 
   // ISCO 코드 유효성 검증
-  const validISCOCodes = ["0", "1", "2", "3", "4", "5", "6", "7", "8", "9"];
+  const validISCOCodes: string[] = JOB_FIELDS.map((field) => field.code);
   if (!validISCOCodes.includes(profile.jobField.code)) {
     return "ISCO-08 표준 직무 분류 코드를 선택해주세요.";
   }
@@ -152,17 +145,7 @@ function validateGuestProfile(profile: UserCareerProfile): string | null {
   }
 
   // 언어 검증
-  const supportedLanguages = [
-    "English",
-    "Japanese",
-    "Chinese",
-    "German",
-    "French",
-    "Spanish",
-    "Korean",
-    "Other",
-  ];
-  if (!supportedLanguages.includes(profile.language)) {
+  if (!SUPPORTED_LANGUAGES.includes(profile.language as any)) {
     return "지원되는 언어를 선택해주세요.";
   }
 

--- a/src/docs/authDocs.ts
+++ b/src/docs/authDocs.ts
@@ -85,5 +85,47 @@ export const authSwaggerDocs = {
         },
       },
     },
+    "/api/auth/kakao": {
+      get: {
+        summary: "카카오 로그인 URL 생성 API",
+        description:
+          "카카오 인증을 위한 URL을 생성합니다.\n\n" +
+          "사용 방법:\n" +
+          "1. 이 API를 호출하여 authUrl을 받습니다\n" +
+          "2. 받은 authUrl을 브라우저에서 엽니다\n" +
+          "3. 카카오 로그인 완료 후 사용자 정보와 JWT 토큰이 포함된 응답을 받습니다\n" +
+          "4. 받은 토큰을 Swagger의 Authorize 버튼에 입력하여 다른 API를 테스트할 수 있습니다\n\n",
+        tags: ["Auth"],
+        responses: {
+          "200": {
+            description: "카카오 인증 URL 생성 성공",
+            content: {
+              "application/json": {
+                schema: {
+                  type: "object",
+                  properties: {
+                    code: { type: "number", example: 200 },
+                    message: {
+                      type: "string",
+                      example: "카카오 인증 URL 생성 성공",
+                    },
+                    data: {
+                      type: "object",
+                      properties: {
+                        authUrl: {
+                          type: "string",
+                          example:
+                            "https://kauth.kakao.com/oauth/authorize?client_id=xxx&redirect_uri=xxx&response_type=code",
+                        },
+                      },
+                    },
+                  },
+                },
+              },
+            },
+          },
+        },
+      },
+    },
   },
 };

--- a/src/models/User.ts
+++ b/src/models/User.ts
@@ -6,9 +6,11 @@ export interface UserDocument extends mongoose.Document {
   _id: mongoose.Types.ObjectId;
   name: string;
   email: string;
-  password: string;
+  password?: string; // 카카오 로그인 시 비밀번호가 없을 수 있음
   birth?: string;
   phone?: string;
+  kakaoId?: string; // 카카오 고유 ID
+  provider?: string; // 'local' 또는 'kakao'
   createdAt: Date;
   matchPassword(enteredPassword: string): Promise<boolean>;
 }
@@ -16,15 +18,17 @@ export interface UserDocument extends mongoose.Document {
 const UserSchema = new mongoose.Schema({
   name: { type: String, required: true },
   email: { type: String, required: true, unique: true },
-  password: { type: String, required: true },
+  password: { type: String }, // required 제거 (카카오 로그인 사용자는 비밀번호 없음)
   birth: { type: String }, //(ex: "2001-03-19")
   phone: { type: String },
+  kakaoId: { type: String, unique: true, sparse: true }, // 카카오 고유 ID
+  provider: { type: String, enum: ["local", "kakao"], default: "local" }, // 로그인 제공자
   createdAt: { type: Date, default: Date.now },
 });
 
 // 비밀번호 해싱 (저장 전 암호화)
 UserSchema.pre("save", async function (next) {
-  if (!this.isModified("password")) return next();
+  if (!this.isModified("password") || !this.password) return next();
   const salt = await bcrypt.genSalt(10);
   this.password = await bcrypt.hash(this.password, salt);
   next();

--- a/src/routes/authRoutes.ts
+++ b/src/routes/authRoutes.ts
@@ -1,14 +1,25 @@
 import express from "express";
-import { register, login } from "../controllers/authController";
+import {
+  register,
+  login,
+  getKakaoAuthUrl,
+  kakaoCallback,
+} from "../controllers/authController";
 import { protect } from "../middlewares/authMiddleware";
 import { asyncHandler } from "../utils/asyncHandler";
 
 const router = express.Router();
 
-// 회원가입
+// 일반 회원가입
 router.post("/register", asyncHandler(register));
 
-// 로그인
+// 일반 로그인
 router.post("/login", asyncHandler(login));
+
+// 카카오 로그인 - 인증 URL 요청
+router.get("/kakao", getKakaoAuthUrl);
+
+// 카카오 로그인 - 콜백
+router.get("/kakao/callback", asyncHandler(kakaoCallback));
 
 export default router;


### PR DESCRIPTION
## 📌 개요
- 카카오 로그인 API 구현

## 🗒️ 작업 내용 요약
- 카카오 로그인 컨트롤러, 라우트 추가, 스키마 수정
.env - 카카오 API 키 및 Redirect URI 설정
- 계정 분리: 일반 회원과 카카오 회원을 명확히 구분
일반 회원 → 카카오 로그인 시도 시 에러, 카카오 회원 → 일반 로그인 시도 시 에러

## 🔗 관련 이슈
- Closes #68 